### PR TITLE
feat: 공통 응답 및 게스트/추천 세션 생성 기능 구현

### DIFF
--- a/src/main/java/com/example/giftrecommender/config/SwaggerConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/SwaggerConfig.java
@@ -1,0 +1,22 @@
+package com.example.giftrecommender.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        Info info = new Info()
+                .title("Gift Recommender API")
+                .description("선물 추천 API 명세서입니다.")
+                .version("v1.0.0");
+
+        return new OpenAPI().info(info);
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/controller/GuestController.java
+++ b/src/main/java/com/example/giftrecommender/controller/GuestController.java
@@ -1,0 +1,34 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.common.BasicResponseDto;
+import com.example.giftrecommender.dto.response.GuestResponseDto;
+import com.example.giftrecommender.service.GuestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Guest", description = "비회원 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/guests")
+public class GuestController {
+
+    private final GuestService guestService;
+
+    @Operation(summary = "비회원 생성", description = "UUID를 기반으로 비회원 세션을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비회원 세션 생성 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PostMapping
+    public ResponseEntity<BasicResponseDto<GuestResponseDto>> createGuest() {
+        return ResponseEntity.ok(BasicResponseDto.success("비회원 세션 생성 완료.", guestService.createGuest()));
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/controller/RecommendationSessionController.java
+++ b/src/main/java/com/example/giftrecommender/controller/RecommendationSessionController.java
@@ -1,0 +1,43 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.common.BasicResponseDto;
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
+import com.example.giftrecommender.service.RecommendationSessionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "추천 세션", description = "추천 세션 생성 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recommendation-session")
+public class RecommendationSessionController {
+
+    private final RecommendationSessionService recommendationSessionService;
+
+    @Operation(
+            summary = "추천 세션 생성",
+            description = "게스트 ID를 기반으로 새로운 추천 세션을 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 세션 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게스트 정보 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PostMapping
+    public ResponseEntity<BasicResponseDto<RecommendationSessionResponseDto>> createRecommendationSession(
+            @RequestBody RecommendationSessionRequestDto requestDto) {
+        return ResponseEntity.ok(BasicResponseDto.success("추천 세션 등록",
+                recommendationSessionService.createRecommendationSession(requestDto)));
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/Guest.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/Guest.java
@@ -1,0 +1,39 @@
+package com.example.giftrecommender.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Guest {
+
+    @Id
+    private UUID id;
+
+    // 생성 시간
+    private LocalDateTime createdAt;
+
+    // 마지막 접속 시간
+    private LocalDateTime lastAccessedAt;
+
+    @Builder
+    public Guest(UUID id) {
+        this.id = id;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.lastAccessedAt = this.createdAt;
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
@@ -1,0 +1,45 @@
+package com.example.giftrecommender.domain.entity;
+
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED
+)
+public class RecommendationSession {
+
+    @Id
+    @Column(name = "recommendation_session_id")
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "guest_id")
+    private Guest guest;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime endedAt;
+
+    @Enumerated(EnumType.STRING)
+    private SessionStatus status;
+
+    @Builder
+    public RecommendationSession(UUID id, Guest guest, SessionStatus status) {
+        this.id = id;
+        this.guest = guest;
+        this.status = status;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/enums/SessionStatus.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/SessionStatus.java
@@ -1,0 +1,5 @@
+package com.example.giftrecommender.domain.enums;
+
+public enum SessionStatus {
+    PENDING, COMPLETED
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/GuestRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/GuestRepository.java
@@ -1,0 +1,9 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Guest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GuestRepository extends JpaRepository<Guest, UUID> {
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/RecommendationSessionRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/RecommendationSessionRepository.java
@@ -1,0 +1,13 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.RecommendationSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RecommendationSessionRepository extends JpaRepository<RecommendationSession, UUID> {
+
+    Optional<RecommendationSession> findTopByGuestIdOrderByCreatedAtDesc(UUID guestId);
+
+}

--- a/src/main/java/com/example/giftrecommender/dto/request/RecommendationSessionRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/RecommendationSessionRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+public record RecommendationSessionRequestDto(
+        @Schema(description = "게스트 ID", example = "a1b2c3d4-e5f6-7890-1234-56789abcdef0")
+        UUID guestId
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/GuestResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/GuestResponseDto.java
@@ -1,0 +1,7 @@
+package com.example.giftrecommender.dto.response;
+
+import java.util.UUID;
+
+public record GuestResponseDto (
+    UUID guestId
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendationSessionResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendationSessionResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+public record RecommendationSessionResponseDto (
+        @Schema(description = "생성된 추천 세션 ID", example = "2f90aa9a-5d10-46b0-a571-3e091354a4d6")
+        UUID recommendationSessionId
+) {}

--- a/src/main/java/com/example/giftrecommender/service/GuestService.java
+++ b/src/main/java/com/example/giftrecommender/service/GuestService.java
@@ -1,0 +1,29 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.repository.GuestRepository;
+import com.example.giftrecommender.dto.response.GuestResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GuestService {
+
+    private final GuestRepository guestRepository;
+
+    @Transactional
+    public GuestResponseDto createGuest() {
+        UUID uuid = UUID.randomUUID();
+        Guest guest = Guest.builder()
+                .id(uuid)
+                .build();
+
+        guestRepository.save(guest);
+        return new GuestResponseDto(uuid);
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
@@ -1,0 +1,42 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.entity.RecommendationSession;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import com.example.giftrecommender.domain.repository.GuestRepository;
+import com.example.giftrecommender.domain.repository.RecommendationSessionRepository;
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationSessionService {
+
+    private final RecommendationSessionRepository recommendationSessionRepository;
+    private final GuestRepository guestRepository;
+
+    @Transactional
+    public RecommendationSessionResponseDto createRecommendationSession(RecommendationSessionRequestDto requestDto) {
+        Guest guest = guestRepository.findById(requestDto.guestId()).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
+        );
+
+        RecommendationSession recommendationSession = RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .guest(guest)
+                .status(SessionStatus.PENDING)
+                .build();
+
+        recommendationSessionRepository.save(recommendationSession);
+        return new RecommendationSessionResponseDto(recommendationSession.getId());
+    }
+
+
+}


### PR DESCRIPTION
## ✨ 주요 변경 사항

### 공통 응답 및 예외 처리
- BasicResponseDto: 모든 API 응답 포맷 통일
- ErrorException, ExceptionEnum: 커스텀 예외 구조 도입
- GlobalExceptionHandler: 전역 예외 처리 설정

### 게스트(Guest)
- Guest 엔티티 및 UUID 기반 저장/조회 기능 구현
- GuestService, GuestController 추가
- GuestRequestDto, GuestResponseDto 구현

### 추천 세션(RecommendationSession)
- RecommendationSession 엔티티 및 SessionStatus enum 정의
- Guest ID를 기반으로 새로운 추천 세션 생성 기능 구현
- RecommendationSessionService, RecommendationSessionController 추가
- 관련 Request/Response DTO 구현

### 기타
- Swagger(OpenAPI) 설정 적용 (`SwaggerConfig`)
- 전체 도메인에 대한 Swagger 문서 태깅 및 예외 응답 정의