### PR TITLE
feat(recommendation): 쿠팡 API 연동 기반 키워드 추천 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
 	// swagger UI
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+
+	// 쿠팡 API 요청 시 HMAC 서명 생성을 위한 commons-codec 유틸
+	implementation 'commons-codec:commons-codec:1.15'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -10,7 +10,9 @@ public enum ExceptionEnum {
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "질문을 찾을 수 없습니다."),
     OPTION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "선택지를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."),
-    INVALID_AI_ANSWER_INDEX(HttpStatus.BAD_REQUEST.value(), "선택된 AI 답변 인덱스가 유효하지 않습니다.");
+    INVALID_AI_ANSWER_INDEX(HttpStatus.BAD_REQUEST.value(), "선택된 AI 답변 인덱스가 유효하지 않습니다."),
+    FORBIDDEN( HttpStatus.FORBIDDEN.value(),"접근 권한이 없습니다."),
+    NO_PRODUCT_MATCH(HttpStatus.BAD_REQUEST.value(), "추천 조건에 맞는 상품이 없습니다.");
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/controller/RecommendationController.java
+++ b/src/main/java/com/example/giftrecommender/controller/RecommendationController.java
@@ -1,0 +1,48 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.common.BasicResponseDto;
+import com.example.giftrecommender.dto.request.RecommendationRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import com.example.giftrecommender.service.RecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "06-추천 API", description = "키워드 기반 선물 추천 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/guests/{guestId}/recommendation-sessions/{sessionId}")
+public class RecommendationController {
+
+    private final RecommendationService recommendationService;
+
+    @Operation(summary = "선물 추천 요청", description = "대표 키워드와 가격 조건을 기반으로 상품을 추천받습니다. (시간당 호출 10회 제한)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 성공",
+                    content = @Content(schema = @Schema(implementation = RecommendationResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "게스트 또는 세션 없음")
+    })
+    @PostMapping("/recommendation")
+    public ResponseEntity<BasicResponseDto<RecommendationResponseDto>> getRecommendation(
+            @Parameter(description = "게스트 식별자", example = "0f7c2913-f43a-44ff-b008-ed0499d7962d")
+            @PathVariable("guestId") UUID guestId,
+
+            @Parameter(description = "추천 세션 식별자", example = "120e8f45-b9f0-4bd3-b000-cca4327b14d0")
+            @PathVariable("sessionId") UUID sessionId,
+
+            @RequestBody RecommendationRequestDto request
+    ) {
+        RecommendationResponseDto response = recommendationService.recommend(guestId, sessionId, request.keywords());
+        return ResponseEntity.ok(BasicResponseDto.success("추천 완료", response));
+    }
+}

--- a/src/main/java/com/example/giftrecommender/controller/RecommendationSessionController.java
+++ b/src/main/java/com/example/giftrecommender/controller/RecommendationSessionController.java
@@ -1,7 +1,7 @@
 package com.example.giftrecommender.controller;
 
 import com.example.giftrecommender.common.BasicResponseDto;
-import com.example.giftrecommender.dto.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
 import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
 import com.example.giftrecommender.service.RecommendationSessionService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/example/giftrecommender/domain/entity/Product.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/Product.java
@@ -1,0 +1,87 @@
+package com.example.giftrecommender.domain.entity;
+
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private UUID publicId;
+
+    @Column(nullable = false)
+    private Long coupangProductId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "longtext")
+    private String imageUrl;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "longtext")
+    private String productUrl;
+
+    // 쿠팡 검색 랭킹 정보
+    @Column(name = "product_rank")
+    private Integer rank;
+
+    // 로켓배송 여부
+    private boolean isRocket;
+
+    // 무료배송 여부
+    private boolean isFreeShipping;
+
+    @ManyToMany
+    @JoinTable(
+            name = "product_keyword",
+            joinColumns = @JoinColumn(name = "product_id"),
+            inverseJoinColumns = @JoinColumn(name = "keyword_group_id")
+    )
+    private List<KeywordGroup> keywordGroups;
+
+    // 저장 시점 (TTL 관리 목적)
+    @Column(nullable = false)
+    private LocalDateTime cachedAt;
+
+    @Builder
+    public Product(UUID publicId, Long coupangProductId, String title, Integer price, String imageUrl,
+                   String productUrl, Integer rank, boolean isRocket, boolean isFreeShipping,
+                   List<KeywordGroup> keywordGroups) {
+        this.publicId = publicId;
+        this.coupangProductId = coupangProductId;
+        this.title = title;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.productUrl = productUrl;
+        this.rank = rank;
+        this.isRocket = isRocket;
+        this.isFreeShipping = isFreeShipping;
+        this.keywordGroups = keywordGroups;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.cachedAt = this.cachedAt == null ? LocalDateTime.now() : this.cachedAt;
+        this.publicId = this.publicId == null ? UUID.randomUUID() : this.publicId;
+    }
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
@@ -1,0 +1,29 @@
+package com.example.giftrecommender.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendationProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "recommendation_result_id", nullable = false)
+    private RecommendationResult recommendationResult;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    public RecommendationProduct(RecommendationResult recommendationResult, Product product) {
+        this.recommendationResult = recommendationResult;
+        this.product = product;
+    }
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationResult.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationResult.java
@@ -1,0 +1,45 @@
+package com.example.giftrecommender.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecommendationResult {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recommendation_result_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "guest_id", nullable = false)
+    private Guest guest;
+
+    @ManyToOne
+    @JoinColumn(name = "recommendation_session_id", nullable = false)
+    private RecommendationSession recommendationSession;
+
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false, columnDefinition = "JSON")
+    private String keywords;
+
+    @Builder
+    public RecommendationResult(Guest guest, RecommendationSession recommendationSession, String keywords) {
+        this.guest = guest;
+        this.recommendationSession = recommendationSession;
+        this.keywords = keywords;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
@@ -12,8 +12,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED
-)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecommendationSession {
 
     @Id

--- a/src/main/java/com/example/giftrecommender/domain/entity/keyword/KeywordGroup.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/keyword/KeywordGroup.java
@@ -1,0 +1,25 @@
+package com.example.giftrecommender.domain.entity.keyword;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class KeywordGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "keyword_group_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String mainKeyword;
+
+    public KeywordGroup(String mainKeyword) {
+        this.mainKeyword = mainKeyword;
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
@@ -3,6 +3,8 @@ package com.example.giftrecommender.domain.repository;
 import com.example.giftrecommender.domain.entity.Product;
 import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,6 +12,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     boolean existsByCoupangProductId(Long coupangProductId);
 
-    List<Product> findByKeywordGroupsContains(KeywordGroup keywordGroup);
+    @Query("SELECT DISTINCT p FROM Product p JOIN p.keywordGroups kg WHERE kg.mainKeyword LIKE %:keyword%")
+    List<Product> findByKeyword(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
@@ -1,0 +1,15 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    boolean existsByCoupangProductId(Long coupangProductId);
+
+    List<Product> findByKeywordGroupsContains(KeywordGroup keywordGroup);
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/RecommendationProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/RecommendationProductRepository.java
@@ -1,0 +1,7 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.RecommendationProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendationProductRepository extends JpaRepository<RecommendationProduct, Long> {
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/RecommendationResultRepository.java
@@ -1,0 +1,7 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.RecommendationResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendationResultRepository extends JpaRepository<RecommendationResult, Long> {
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.domain.repository.keyword;
+
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface KeywordGroupRepository extends JpaRepository<KeywordGroup, Long> {
+
+    List<KeywordGroup> findByMainKeywordIn(List<String> mainKeywords);
+
+    Optional<KeywordGroup> findByMainKeyword(String mainKeyword);
+}

--- a/src/main/java/com/example/giftrecommender/dto/request/RecommendationRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/RecommendationRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record RecommendationRequestDto(
+        @Schema(description = "대표 키워드 목록", example = "[\"연인\", \"5만원 이상 10만원 이하\", \"운동\", \"다이어트\"]")
+        List<String> keywords
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/RecommendationSessionRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/RecommendationSessionRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto;
+package com.example.giftrecommender.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendationResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendationResponseDto.java
@@ -1,0 +1,7 @@
+package com.example.giftrecommender.dto.response;
+
+import java.util.List;
+
+public record RecommendationResponseDto(
+        List<RecommendedProductResponseDto> products
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendedProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendedProductResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.giftrecommender.dto.response;
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+
+import java.util.List;
+import java.util.UUID;
+
+public record RecommendedProductResponseDto(
+        UUID publicId,
+        String title,
+        int price,
+        String imageUrl,
+        String productUrl,
+        List<String> keywords
+) {
+    public static RecommendedProductResponseDto from(Product product) {
+        List<String> keywordTags = product.getKeywordGroups().stream()
+                .map(KeywordGroup::getMainKeyword)
+                .toList();
+
+        return new RecommendedProductResponseDto(
+                product.getPublicId(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getImageUrl(),
+                product.getProductUrl(),
+                keywordTags
+        );
+    }
+}

--- a/src/main/java/com/example/giftrecommender/infra/coupang/CoupangApiClient.java
+++ b/src/main/java/com/example/giftrecommender/infra/coupang/CoupangApiClient.java
@@ -1,0 +1,93 @@
+package com.example.giftrecommender.infra.coupang;
+
+import com.example.giftrecommender.infra.coupang.config.CoupangApiConfig;
+import com.example.giftrecommender.infra.coupang.dto.CoupangProductResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CoupangApiClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final CoupangApiConfig config;
+
+    public List<CoupangProductResponseDto> searchProducts(String keyword) {
+        try {
+            // keyword를 인코딩
+            String encodedKeyword = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
+            String rawQuery = "keyword=" + encodedKeyword;
+
+            // 요청 경로 및 전체 URL 구성
+            String method = "GET";
+            String path = "/v2/providers/affiliate_open_api/apis/openapi/v1/products/search";
+            String uriWithQuery = path + "?" + rawQuery;
+            String fullUrl = "https://api-gateway.coupang.com" + uriWithQuery;
+
+            // HMAC 서명용 timestamp 생성 (UTC/GMT 기준)
+            String timestamp = CoupangAuthUtil.generateTimestamp();
+
+            // 쿠팡 API용 Authorization 헤더 생성 (RFC2104 HMAC-SHA256 방식)
+            String authorization = CoupangAuthUtil.generateAuthorization(
+                    method, path, rawQuery, config.getSecretKey(), config.getAccessKey(), timestamp
+            );
+
+            // Header 구성
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", authorization);
+            headers.set("X-Timestamp", timestamp);
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            log.info("[쿠팡 API 호출 정보]");
+            log.info("keyword: {}", keyword);
+            log.info("rawQuery: {}", rawQuery);
+            log.info("authorization: {}", authorization);
+            log.info("full URL: {}", fullUrl);
+
+            // URI 객체로 직접 생성해서 RestTemplate 전달 → 자동 인코딩 방지
+            URI uri = new URI(fullUrl);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri, HttpMethod.GET, new HttpEntity<>(headers), String.class
+            );
+
+            if (response.getStatusCode() == HttpStatus.OK) {
+                return productsResponseDto(response.getBody());
+            } else {
+                log.warn("❌ 쿠팡 API 실패 - Status: {}", response.getStatusCode());
+                log.warn("Body: {}", response.getBody());
+                return List.of();
+            }
+        } catch (Exception e) {
+            log.error("🚨 쿠팡 API 호출 중 예외 발생", e);
+            return List.of();
+        }
+    }
+
+    /**
+     * 응답 JSON에서 productData 파싱
+     */
+    private List<CoupangProductResponseDto> productsResponseDto(String body) throws Exception {
+        List<CoupangProductResponseDto> responseDto = new ArrayList<>();
+        JsonNode productData = objectMapper.readTree(body).path("data").path("productData");
+
+        for (JsonNode item : productData) {
+            responseDto.add(CoupangProductResponseDto.of(item));
+        }
+        return responseDto;
+    }
+
+}
+

--- a/src/main/java/com/example/giftrecommender/infra/coupang/CoupangAuthUtil.java
+++ b/src/main/java/com/example/giftrecommender/infra/coupang/CoupangAuthUtil.java
@@ -1,0 +1,65 @@
+package com.example.giftrecommender.infra.coupang;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Hex;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * 쿠팡 OpenAPI 인증 유틸리티 클래스
+ * - RFC2104 HMAC-SHA256 기반 서명 생성
+ * - 쿠팡 API 호출 시 Authorization 헤더 생성에 사용
+ */
+@Slf4j
+public class CoupangAuthUtil {
+
+    private static final String ALGORITHM = "HmacSHA256";
+
+    /**
+     * HMAC 서명 기반 Authorization 문자열 생성
+     *
+     * @param method     HTTP 메서드 (예: "GET")
+     * @param path       요청 경로 (예: "/v2/providers/affiliate_open_api/apis/openapi/v1/products/search")
+     * @param rawQuery   쿼리 파라미터 문자열 (예: "keyword=인코딩된 키워드")
+     * @param secretKey  쿠팡 제공 Secret Key
+     * @param accessKey  쿠팡 제공 Access Key
+     * @param timestamp  요청 시점의 타임스탬프 ("yyMMdd'T'HHmmss'Z'" 형식)
+     * @return Authorization 헤더 값
+     *
+     * message 형식: {timestamp}{method}{path}{query}
+     */
+    public static String generateAuthorization(String method, String path, String rawQuery,
+                                               String secretKey, String accessKey, String timestamp) {
+        try {
+            // 서명 대상 문자열 조합 (중요: ? 없이 path+query 연결)
+            String message = timestamp + method + path + rawQuery;
+            log.info("🧾 HMAC message = {}", message);
+
+            // HMAC-SHA256 알고리즘 기반 서명 생성
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), ALGORITHM));
+            String signature = Hex.encodeHexString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)));
+
+            // 최종 Authorization 포맷 구성
+            return String.format("CEA algorithm=%s, access-key=%s, signed-date=%s, signature=%s",
+                    ALGORITHM, accessKey, timestamp, signature);
+        } catch (Exception e) {
+            throw new RuntimeException("HMAC 생성 실패", e);
+        }
+    }
+
+    /**
+     * 쿠팡 HMAC 요청용 timestamp 생성 (ex. 240512T081200Z)
+     */
+    public static String generateTimestamp() {
+        SimpleDateFormat dateFormatGmt = new SimpleDateFormat("yyMMdd'T'HHmmss'Z'");
+        dateFormatGmt.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return dateFormatGmt.format(new Date());
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/infra/coupang/config/CoupangApiConfig.java
+++ b/src/main/java/com/example/giftrecommender/infra/coupang/config/CoupangApiConfig.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.infra.coupang.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class CoupangApiConfig {
+    @Value("${coupang.access-key}")
+    private String accessKey;
+    @Value("${coupang.secret-key}")
+    private String secretKey;
+}

--- a/src/main/java/com/example/giftrecommender/infra/coupang/dto/CoupangProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/infra/coupang/dto/CoupangProductResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.giftrecommender.infra.coupang.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Builder;
+
+@Builder
+public record CoupangProductResponseDto(
+        Long coupangProductId,
+        String title,
+        String imageUrl,
+        String productUrl,
+        Integer price,
+        String keyword,
+        Integer rank,
+        boolean isRocket,
+        boolean isFreeShipping
+) {
+    public static CoupangProductResponseDto of(JsonNode item) {
+        return CoupangProductResponseDto.builder()
+                .coupangProductId(item.path("productId").asLong())
+                .title(item.path("productName").asText())
+                .imageUrl(item.path("productImage").asText())
+                .productUrl(item.path("productUrl").asText())
+                .price(item.path("productPrice").asInt())
+                .keyword(item.path("keyword").asText())
+                .rank(item.path("rank").asInt())
+                .isRocket(item.path("isRocket").asBoolean())
+                .isFreeShipping(item.path("isFreeShipping").asBoolean())
+                .build();
+    }
+}

--- a/src/main/java/com/example/giftrecommender/service/ProductImportService.java
+++ b/src/main/java/com/example/giftrecommender/service/ProductImportService.java
@@ -1,0 +1,69 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.repository.ProductRepository;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.infra.coupang.CoupangApiClient;
+import com.example.giftrecommender.infra.coupang.dto.CoupangProductResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductImportService {
+
+    private final CoupangApiClient coupangApiClient;
+    private final ProductRepository productRepository;
+    private final KeywordGroupRepository keywordGroupRepository;
+
+    @Transactional
+    public void importUntilEnough(String queryKeyword, String mainKeyword, int neededCount) {
+        if (queryKeyword == null || queryKeyword.isBlank()) {
+            log.warn("상품 가져오기 실패: 키워드 없음");
+            return;
+        }
+
+        KeywordGroup keywordGroup = keywordGroupRepository.findByMainKeyword(mainKeyword)
+                .orElseGet(() -> keywordGroupRepository.save(new KeywordGroup(mainKeyword)));
+
+        log.info("쿠팡 API 단일 페이지 호출 (페이지=1): '{}'", queryKeyword);
+
+        List<CoupangProductResponseDto> response = coupangApiClient.searchProducts(queryKeyword, 1);
+
+        int saveProduct = 0;
+        for (CoupangProductResponseDto dto : response) {
+            long coupangId = dto.coupangProductId();
+
+            if (productRepository.existsByCoupangProductId(coupangId)) {
+                log.debug("중복 저장 스킵(DB): {}", coupangId);
+                continue;
+            }
+
+            Product p = Product.builder()
+                    .productUrl(UUID.randomUUID().toString())
+                    .coupangProductId(coupangId)
+                    .title(dto.title())
+                    .price(dto.price())
+                    .imageUrl(dto.imageUrl())
+                    .productUrl(dto.productUrl())
+                    .rank(dto.rank())
+                    .isRocket(dto.isRocket())
+                    .isFreeShipping(dto.isFreeShipping())
+                    .keywordGroups(List.of(keywordGroup))
+                    .build();
+            productRepository.save(p);
+            saveProduct++;
+
+            if (saveProduct >= neededCount) break;
+        }
+
+        log.info("단일 페이지 수집 완료: {}개 (목표={})", saveProduct, neededCount);
+    }
+}
+

--- a/src/main/java/com/example/giftrecommender/service/RecommendationService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationService.java
@@ -1,0 +1,134 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.domain.entity.*;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.repository.*;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import com.example.giftrecommender.dto.response.RecommendedProductResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecommendationService {
+
+    private final GuestRepository guestRepository;
+    private final RecommendationSessionRepository sessionRepository;
+    private final ProductRepository productRepository;
+    private final RecommendationResultRepository resultRepository;
+    private final RecommendationProductRepository recommendationProductRepository;
+    private final KeywordGroupRepository keywordGroupRepository;
+    private final ProductImportService productService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    public RecommendationResponseDto recommend(UUID guestId, UUID sessionId, List<String> keywords) {
+        Guest guest = existsGuest(guestId);
+        RecommendationSession session = existsRecommendationSession(sessionId);
+
+        // 가격 필터 분리
+        String priceFilter = keywords.stream()
+                .filter(k -> k.contains("이하") || k.contains("이상"))
+                .findFirst()
+                .orElse("전체");
+
+        List<String> tagKeywords = keywords.stream()
+                .filter(k -> !k.contains("이하") && !k.contains("이상"))
+                .toList();
+
+        // 전체 키워드 문자열로 조합
+        String combinedKeyword = String.join(" ", tagKeywords);
+        String keywordJson = toJson(keywords);
+
+        // 1. DB에서 먼저 조회
+        List<Product> products = productRepository.findByKeyword(combinedKeyword);
+        List<Product> allCandidates = new ArrayList<>(products);
+
+        // 2. 충분하지 않으면 외부 API 호출 후 저장
+        if (products.size() < 4) {
+            log.info("{} 키워드로 DB에 부족하여 외부 API 호출", combinedKeyword);
+            productService.importUntilEnough(combinedKeyword, combinedKeyword, 4);
+            List<Product> newProducts = productRepository.findByKeyword(combinedKeyword);
+            allCandidates.addAll(newProducts);
+        } else {
+            log.info("{} 키워드로 DB에 충분한 상품이 있어 API 생략", combinedKeyword);
+        }
+
+        // 중복 제거 후 가격 및 태그 필터링
+        List<Product> filtered = allCandidates.stream()
+                .distinct()
+                .filter(p -> matchesPrice(p.getPrice(), priceFilter))
+                .filter(p -> matchesTags(p.getKeywordGroups(), tagKeywords))
+                .limit(4)
+                .toList();
+
+        RecommendationResult result = resultRepository.save(RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(session)
+                .keywords(keywordJson)
+                .build());
+
+        List<RecommendationProduct> recProducts = filtered.stream()
+                .map(p -> new RecommendationProduct(result, p))
+                .toList();
+        recommendationProductRepository.saveAll(recProducts);
+
+        return new RecommendationResponseDto(
+                filtered.stream().map(RecommendedProductResponseDto::from).toList()
+        );
+    }
+
+    private Guest existsGuest(UUID guestId) {
+        return guestRepository.findById(guestId).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
+        );
+    }
+
+    private RecommendationSession existsRecommendationSession(UUID sessionId) {
+        return sessionRepository.findById(sessionId).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND)
+        );
+    }
+
+    private String toJson(List<String> keywords) {
+        try {
+            return objectMapper.writeValueAsString(keywords);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 변경 실패", e);
+        }
+    }
+
+    private boolean matchesPrice(int price, String priceFilter) {
+        return switch (priceFilter) {
+            case "5만원 이하" -> price <= 50000;
+            case "5만원 이상 10만원 이하" -> price >= 50000 && price <= 100000;
+            case "10만원 이상 20만원 이하" -> price >= 100000 && price <= 200000;
+            case "20만원 이상" -> price >= 200000;
+            default -> true;
+        };
+    }
+
+    private boolean matchesTags(List<KeywordGroup> keywordGroups, List<String> tagKeywords) {
+        List<String> productTags = keywordGroups.stream()
+                .map(KeywordGroup::getMainKeyword)
+                .toList();
+
+        long matchCount = tagKeywords.stream()
+                .filter(productTags::contains)
+                .count();
+
+        return matchCount >= Math.ceil(tagKeywords.size() / 2.0);
+    }
+
+
+}

--- a/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
@@ -7,7 +7,7 @@ import com.example.giftrecommender.domain.entity.RecommendationSession;
 import com.example.giftrecommender.domain.enums.SessionStatus;
 import com.example.giftrecommender.domain.repository.GuestRepository;
 import com.example.giftrecommender.domain.repository.RecommendationSessionRepository;
-import com.example.giftrecommender.dto.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
 import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/giftrecommender/service/UserAnswerService.java
+++ b/src/main/java/com/example/giftrecommender/service/UserAnswerService.java
@@ -37,13 +37,13 @@ public class UserAnswerService {
 
     @Transactional
     public void saveAnswer(UUID guestId, UUID sessionId, UserAnswerRequestDto request) {
-        Guest guest = guestRepository.findById(guestId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
-        );
+        Guest guest = existsGuest(guestId);
 
-        RecommendationSession session = sessionRepository.findById(sessionId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND)
-        );
+        RecommendationSession session = existsRecommendationSession(sessionId);
+
+        if (!session.getGuest().getId().equals(guest.getId())) {
+            throw new ErrorException(ExceptionEnum.FORBIDDEN);
+        }
 
         Question question = questionRepository.findById(request.questionId()).orElseThrow(
                 () -> new ErrorException(ExceptionEnum.QUESTION_NOT_FOUND)
@@ -59,13 +59,13 @@ public class UserAnswerService {
 
     @Transactional
     public void saveAiQuestionAndAnswer(UUID guestId, UUID sessionId, UserAnswerAiRequestDto requestDto) {
-        Guest guest = guestRepository.findById(guestId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
-        );
+        Guest guest = existsGuest(guestId);
 
-        RecommendationSession session = sessionRepository.findById(sessionId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND)
-        );
+        RecommendationSession session = existsRecommendationSession(sessionId);
+
+        if (!session.getGuest().getId().equals(guest.getId())) {
+            throw new ErrorException(ExceptionEnum.FORBIDDEN);
+        }
 
         AiQuestion question = AiQuestion.builder()
                 .guest(guest)
@@ -93,6 +93,18 @@ public class UserAnswerService {
 
         UserAnswer userAnswer = UserAnswer.ofAi(guest, session, question, selectedOption, requestDto.question().type());
         userAnswerRepository.save(userAnswer);
+    }
+
+    private Guest existsGuest(UUID guestId) {
+        return guestRepository.findById(guestId).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
+        );
+    }
+
+    private RecommendationSession existsRecommendationSession(UUID sessionId) {
+        return sessionRepository.findById(sessionId).orElseThrow(
+                () -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND)
+        );
     }
 
 


### PR DESCRIPTION
## 💡 주요 기능 구현 내역
### 쿠팡 상품 검색 및 추천 시스템
- 상품 도메인 구성
  - `Product` 엔티티 구현: 쿠팡 상품 정보(상품명, 가격, 이미지, 상품 외부 링크 등) 포함
  - `KeywordGroup` 엔티티 추가: 상품 키워드 분류용

### 쿠팡 API 연동
- HMAC 인증을 위한 유틸 클래스 및 설정 클래스 구성
- 상품 검색 API 클라이언트 구현 (`CoupangApiClient`)
- commons-codec 의존성 추가 (서명 생성용)

### 상품 수집 서비스
- 단일 페이지 기준 상품 수집 기능 (`ProductImportService.importUntilEnough`)
- 중복 저장 방지 및 키워드 연동 처리

## 키워드 기반 추천 API
- 추천 도메인 설계
  - `RecommendationResult`: 추천 키워드 및 추천 세션, 비회원저장
  - `RecommendationProduct`: 추천된 상품 리스트 저장
- 추천 서비스 구현
  - `/api/guests/{guestId}/recommendation-sessions/{sessionId}/recommendation` API: 게스트 ID, 추천 세션 ID, 키워드 리스트 기반 추천 결과 반환
  - 입력된 키워드를 하나의 문자열로 조합하여 검색 -> API 호출 최소화
  - 가격 조건 필터 및 키워드 태그 과반수 일치 조건으로 후보 필터링

## 기타 공통 개선 사항
- 추천 실패 시 예외 정의: `NO_PRODUCT_MATCH`, `FORBIDDEN`
- JSON 응답 및 쿠팡 API 디버깅을 위한 로깅 로직 개선
- Swagger 문서 태그 정리

## 참고 사항
- 쿠팡파트너스 API의 검색 API 호출 횟수 제한
  - 시간당 10회로 제한
    (위반 시 24시간 제한, 3회 이상 위반 시 계정 사용 불가)