### PR TITLE
feat(logging): 요청/응답 바디 로깅 및 traceId 추적 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/application-secret.yml
+logs/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/example/giftrecommender/common/logging/filter/RequestLoggingFilter.java
+++ b/src/main/java/com/example/giftrecommender/common/logging/filter/RequestLoggingFilter.java
@@ -1,0 +1,61 @@
+package com.example.giftrecommender.common.logging.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+
+        String traceId = UUID.randomUUID().toString();
+        MDC.put(TRACE_ID, traceId);
+
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse);
+            logRequest(wrappedRequest, traceId);
+        } finally {
+            wrappedResponse.copyBodyToResponse();
+            MDC.clear();
+        }
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request, String traceId) {
+        MDC.put(TRACE_ID, traceId);
+
+        String contentType = request.getContentType();
+
+        if (request.getContentLength() == 0) {
+            log.info("Request [{}] body is empty", traceId);
+            return;
+        }
+
+        if (contentType != null && contentType.contains("application/json")) {
+            String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+            log.info("Request [{}] JSON body: {}", traceId, body);
+        } else {
+            log.info("Request [{}] Unsupported content-type: {}", traceId, contentType);
+        }
+
+    }
+}

--- a/src/main/java/com/example/giftrecommender/common/logging/interceptor/ResponseLoggingInterceptor.java
+++ b/src/main/java/com/example/giftrecommender/common/logging/interceptor/ResponseLoggingInterceptor.java
@@ -1,0 +1,33 @@
+package com.example.giftrecommender.common.logging.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class ResponseLoggingInterceptor implements HandlerInterceptor {
+
+    private static final String TRACE_ID = "traceId";
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+                                Object handler, Exception ex) throws Exception {
+        String traceId = MDC.get(TRACE_ID);
+
+        if (response instanceof ContentCachingResponseWrapper wrapper) {
+            String responseBody = new String(wrapper.getContentAsByteArray(), StandardCharsets.UTF_8);
+            log.info("Response [{}] Status: {}, Body: {}", traceId, response.getStatus(), responseBody);
+        } else {
+            log.info("Response [{}] Status: {}", traceId, response.getStatus());
+        }
+
+        MDC.clear();
+    }
+}

--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.example.giftrecommender.config;
+
+import com.example.giftrecommender.common.logging.interceptor.ResponseLoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final ResponseLoggingInterceptor loggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor);
+    }
+
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %highlight(%5level) %cyan(%logger) - %magenta(%msg) traceId=%X{traceId}%n"/>
+    <property name="LOG_FILE" value="logs/application.log" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/application.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="com.example.giftrecommender" level="DEBUG"/>
+
+    <springProfile name="local">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 💡 주요 변경 사항
- 요청(Request)에 대해 JSON 바디 로깅 필터(`RequestLoggingFilter`) 추가
- 응답(Response)에 대해 상태코드 및 바디 로깅 인터셉터(`ResponseLoggingInterceptor`) 추가
- traceId를 MDC를 통해 각 로그에 자동 삽입되도록 구성
- Logback 설정에 traceId 포함 및 콘솔/파일 분리 로그 출력 설정
- `WebConfig`에 인터셉터 등록 완료

## 기타
- 운영 환경에서는 콘솔 로그 제외 (`logback-spring.xml`의 `springProfile` 활용)
- `logs/` 관련 경로 .gitignore에 추가