### PR TITLE
Refactor/recommend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 
 	// 쿠팡 API 요청 시 HMAC 서명 생성을 위한 commons-codec 유틸
 	implementation 'commons-codec:commons-codec:1.15'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Guava RateLimiter
+	implementation 'com.google.guava:guava:32.1.2-jre'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -12,7 +12,10 @@ public enum ExceptionEnum {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."),
     INVALID_AI_ANSWER_INDEX(HttpStatus.BAD_REQUEST.value(), "선택된 AI 답변 인덱스가 유효하지 않습니다."),
     FORBIDDEN( HttpStatus.FORBIDDEN.value(),"접근 권한이 없습니다."),
-    NO_PRODUCT_MATCH(HttpStatus.BAD_REQUEST.value(), "추천 조건에 맞는 상품이 없습니다.");
+    NO_PRODUCT_MATCH(HttpStatus.BAD_REQUEST.value(), "추천 조건에 맞는 상품이 없습니다."),
+    QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다."),
+    RESULT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "추천 결과를 찾을 수 없습니다."),
+    SESSION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "세션 접근 권한이 없습니다.");
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
+++ b/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
@@ -1,0 +1,50 @@
+package com.example.giftrecommender.common.quota;
+
+import com.google.common.util.concurrent.RateLimiter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisQuotaManager {
+
+    private static final String KEY = "naver:quota:count";
+    private static final int DAILY_LIMIT = 25_000;
+    private static final double PERMITS_PER_SECOND = 10.0;
+
+    private final RateLimiter rateLimiter = RateLimiter.create(PERMITS_PER_SECOND);
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean canCall() {
+        // 초당 호출 제한 먼저
+        rateLimiter.acquire();  // blocking: 절대 초과 방지
+
+        // 일일 호출 수 제한 (Redis 저장)
+        Long count = redisTemplate.opsForValue().increment(KEY);
+        if (count == null) count = 0L;
+
+        if (count >= DAILY_LIMIT) {
+            log.warn("네이버 API 호출 초과: {}/{}", count, DAILY_LIMIT);
+            return false;
+        }
+
+        log.debug("네이버 API 호출: {}/{}", count, DAILY_LIMIT);
+        return true;
+    }
+
+    // 매일 00시 초기화
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void resetQuota() {
+        redisTemplate.delete(KEY);
+        log.info("네이버 API 쿼터 초기화 완료");
+    }
+
+    public long getCallCount() {
+        String raw = redisTemplate.opsForValue().get(KEY);
+        return raw != null ? Long.parseLong(raw) : 0L;
+    }
+}

--- a/src/main/java/com/example/giftrecommender/config/SchedulingConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.example.giftrecommender.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/example/giftrecommender/controller/QuestionController.java
+++ b/src/main/java/com/example/giftrecommender/controller/QuestionController.java
@@ -26,7 +26,7 @@ public class QuestionController {
     @Operation(summary = "질문 목록 조회", description = "질문 리스트와 선택지를 조회합니다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "질문 목록 조회 성공"),
-            @ApiResponse(responseCode = "500", description = "서서버 내부 오류")
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping
     public ResponseEntity<BasicResponseDto<List<QuestionResponseDto>>> getQuestions() {

--- a/src/main/java/com/example/giftrecommender/controller/RecommendationController.java
+++ b/src/main/java/com/example/giftrecommender/controller/RecommendationController.java
@@ -34,10 +34,7 @@ public class RecommendationController {
     })
     @PostMapping("/recommendation")
     public ResponseEntity<BasicResponseDto<RecommendationResponseDto>> getRecommendation(
-            @Parameter(description = "게스트 식별자", example = "0f7c2913-f43a-44ff-b008-ed0499d7962d")
             @PathVariable("guestId") UUID guestId,
-
-            @Parameter(description = "추천 세션 식별자", example = "120e8f45-b9f0-4bd3-b000-cca4327b14d0")
             @PathVariable("sessionId") UUID sessionId,
 
             @RequestBody RecommendationRequestDto request
@@ -45,4 +42,24 @@ public class RecommendationController {
         RecommendationResponseDto response = recommendationService.recommend(guestId, sessionId, request.keywords());
         return ResponseEntity.ok(BasicResponseDto.success("추천 완료", response));
     }
+
+    @Operation(
+            summary = "추천 결과 조회",
+            description = "추천 세션 ID(sessionId)를 기반으로 추천 결과를 조회합니다. 추천 생성 이후 다시 확인하거나 재접속 시 사용합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추천 결과 조회 성공",
+                    content = @Content(schema = @Schema(implementation = RecommendationResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "추천 결과 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/recommendation")
+    public ResponseEntity<BasicResponseDto<RecommendationResponseDto>> getRecommendationResult(
+            @PathVariable("guestId") UUID guestId,
+            @PathVariable("sessionId") UUID sessionId
+    ) {
+        RecommendationResponseDto response = recommendationService.getRecommendationResult(guestId, sessionId);
+        return ResponseEntity.ok(BasicResponseDto.success("추천 결과 조회 성공", response));
+    }
+
 }

--- a/src/main/java/com/example/giftrecommender/domain/entity/Guest.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/Guest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -21,21 +21,23 @@ public class Guest {
     @Column(name = "guest_id")
     private UUID id;
 
-    // 생성 시간
-    private LocalDateTime createdAt;
+    // 생성 시간 (UTC)
+    private Instant createdAt;
 
-    // 마지막 접속 시간
-    private LocalDateTime lastAccessedAt;
+    // 마지막 접속 시간 (UTC)
+    private Instant lastAccessedAt;
 
     @Builder
     public Guest(UUID id) {
         this.id = id;
     }
 
+    // 최초 저장 시 자동 세팅
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now();
-        this.lastAccessedAt = this.createdAt;
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.lastAccessedAt = now;
     }
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
@@ -14,11 +14,11 @@ public class RecommendationProduct {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommendation_result_id", nullable = false)
     private RecommendationResult recommendationResult;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationResult.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationResult.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,21 +18,26 @@ public class RecommendationResult {
     @Column(name = "recommendation_result_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommendation_session_id", nullable = false)
     private RecommendationSession recommendationSession;
 
     private LocalDateTime createdAt;
 
-    @Column(nullable = false, columnDefinition = "JSON")
-    private String keywords;
+    @ElementCollection
+    @CollectionTable(
+            name = "recommendation_keywords",
+            joinColumns = @JoinColumn(name = "recommendation_result_id")
+    )
+    @Column(name = "keyword", nullable = false)
+    private List<String> keywords;
 
     @Builder
-    public RecommendationResult(Guest guest, RecommendationSession recommendationSession, String keywords) {
+    public RecommendationResult(Guest guest, RecommendationSession recommendationSession, List<String> keywords) {
         this.guest = guest;
         this.recommendationSession = recommendationSession;
         this.keywords = keywords;

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationSession.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 
 @Entity
@@ -19,18 +19,18 @@ public class RecommendationSession {
     @Column(name = "recommendation_session_id")
     private UUID id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 60)
     private String name;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime endedAt;
+    private Instant createdAt;
+    private Instant endedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private SessionStatus status;
 
     @Builder
@@ -43,7 +43,7 @@ public class RecommendationSession {
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = Instant.now();
     }
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/entity/UserAnswer.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/UserAnswer.java
@@ -7,11 +7,10 @@ import com.example.giftrecommender.domain.entity.question.Question;
 import com.example.giftrecommender.domain.enums.QuestionType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Getter
@@ -22,37 +21,37 @@ public class UserAnswer {
     @Column(name = "user_answer_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommendation_session_id", nullable = false)
     private RecommendationSession recommendationSession;
 
     // 고정 질문(1~3번)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_option_id")
     private AnswerOption answerOption;
 
     // GPT 기반 질문(4~6번)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ai_question_id")
     private AiQuestion aiQuestion;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ai_answer_option_id")
     private AiAnswerOption aiAnswerOption;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private QuestionType type;
 
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     // 고정 질문 생성자
     public UserAnswer(Guest guest, RecommendationSession recommendationSession,
@@ -87,7 +86,7 @@ public class UserAnswer {
 
     @PrePersist
     public void prePersist() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = Instant.now();
     }
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AiAnswerOption.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AiAnswerOption.java
@@ -16,11 +16,11 @@ public class AiAnswerOption {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ai_question_id", nullable = false)
     private AiQuestion question;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 300)
     private String content;
 
     @Column(nullable = false, length = 100)

--- a/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AnswerOption.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AnswerOption.java
@@ -15,13 +15,13 @@ public class AnswerOption {
     @Column(name = "answer_option_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 300)
     private String content;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String recommendationKeyword;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id", nullable = false)
     private Question question;
 

--- a/src/main/java/com/example/giftrecommender/domain/entity/keyword/KeywordGroup.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/keyword/KeywordGroup.java
@@ -15,7 +15,7 @@ public class KeywordGroup {
     @Column(name = "keyword_group_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 100)
     private String mainKeyword;
 
     public KeywordGroup(String mainKeyword) {

--- a/src/main/java/com/example/giftrecommender/domain/entity/question/AiQuestion.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/question/AiQuestion.java
@@ -19,11 +19,11 @@ public class AiQuestion {
     @Column(name = "ai_question_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recommendation_session_id", nullable = false)
     private RecommendationSession session;
 
@@ -31,7 +31,7 @@ public class AiQuestion {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private QuestionType type;
 
     @Column(name = "question_order", nullable = false)

--- a/src/main/java/com/example/giftrecommender/domain/entity/question/Question.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/question/Question.java
@@ -19,7 +19,7 @@ public class Question {
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private QuestionType type;
 
     @Column(name = "question_order", nullable = false)

--- a/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
@@ -7,12 +7,18 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    boolean existsByCoupangProductId(Long coupangProductId);
+    @Query("SELECT p FROM Product p JOIN p.keywordGroups kg WHERE kg.mainKeyword IN :keywords AND p.price BETWEEN :min AND :max")
+    List<Product> findTopByTagsAndPriceRange(
+            @Param("keywords") List<String> keywords,
+            @Param("min") int min,
+            @Param("max") int max
+    );
 
-    @Query("SELECT DISTINCT p FROM Product p JOIN p.keywordGroups kg WHERE kg.mainKeyword LIKE %:keyword%")
-    List<Product> findByKeyword(@Param("keyword") String keyword);
+    @Query("SELECT p.link FROM Product p WHERE p.link IN :links")
+    Set<String> findLinksIn(@Param("links") Set<String> links);
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/repository/RecommendationProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/RecommendationProductRepository.java
@@ -1,7 +1,16 @@
 package com.example.giftrecommender.domain.repository;
 
+import com.example.giftrecommender.domain.entity.Product;
 import com.example.giftrecommender.domain.entity.RecommendationProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RecommendationProductRepository extends JpaRepository<RecommendationProduct, Long> {
+
+    @Query("SELECT rp.product FROM RecommendationProduct rp WHERE rp.recommendationResult.id = :resultId")
+    List<Product> findProductsByResultId(@Param("resultId") Long resultId);
+
 }

--- a/src/main/java/com/example/giftrecommender/domain/repository/RecommendationResultRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/RecommendationResultRepository.java
@@ -3,5 +3,11 @@ package com.example.giftrecommender.domain.repository;
 import com.example.giftrecommender.domain.entity.RecommendationResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface RecommendationResultRepository extends JpaRepository<RecommendationResult, Long> {
+
+    Optional<RecommendationResult> findByRecommendationSessionId(UUID sessionId);
+
 }

--- a/src/main/java/com/example/giftrecommender/dto/request/RecommendationRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/RecommendationRequestDto.java
@@ -5,6 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record RecommendationRequestDto(
-        @Schema(description = "대표 키워드 목록", example = "[\"연인\", \"5만원 이상 10만원 이하\", \"운동\", \"다이어트\"]")
+        @Schema(description = "대표 키워드 목록", example = "[\"여자친구\", \"5~10만원\", \"생일\", \"악세서리\", \"우아한\"]")
         List<String> keywords
 ) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/ProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/ProductResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.giftrecommender.dto.response;
+
+import java.util.UUID;
+
+public record ProductResponseDto(
+        UUID publicId,
+        String title,
+        String link,
+        String image,
+        int lprice,
+        String mallName
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendationResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendationResponseDto.java
@@ -3,5 +3,6 @@ package com.example.giftrecommender.dto.response;
 import java.util.List;
 
 public record RecommendationResponseDto(
+        String name,
         List<RecommendedProductResponseDto> products
 ) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendationSessionResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendationSessionResponseDto.java
@@ -6,5 +6,8 @@ import java.util.UUID;
 
 public record RecommendationSessionResponseDto (
         @Schema(description = "생성된 추천 세션 ID", example = "2f90aa9a-5d10-46b0-a571-3e091354a4d6")
-        UUID recommendationSessionId
+        UUID recommendationSessionId,
+
+        @Schema(description = "생성된 이름", example = "회원1")
+        String name
 ) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/RecommendedProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/RecommendedProductResponseDto.java
@@ -10,8 +10,8 @@ public record RecommendedProductResponseDto(
         UUID publicId,
         String title,
         int price,
+        String link,
         String imageUrl,
-        String productUrl,
         List<String> keywords
 ) {
     public static RecommendedProductResponseDto from(Product product) {
@@ -23,8 +23,8 @@ public record RecommendedProductResponseDto(
                 product.getPublicId(),
                 product.getTitle(),
                 product.getPrice(),
+                product.getLink(),
                 product.getImageUrl(),
-                product.getProductUrl(),
                 keywordTags
         );
     }

--- a/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
+++ b/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
@@ -1,0 +1,88 @@
+package com.example.giftrecommender.infra.naver;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverApiClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final RedisQuotaManager quotaManager;
+
+    @Value("${naver.client-id}")
+    private String clientId;
+
+    @Value("${naver.client-secret}")
+    private String clientSecret;
+
+    public List<ProductResponseDto> search(String query, int page, int display) {
+        if (!quotaManager.canCall()) {
+            throw new ErrorException(ExceptionEnum.QUOTA_EXCEEDED);
+        }
+
+        int start = (page - 1) * display + 1;
+        String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8);
+        String url = "https://openapi.naver.com/v1/search/shop.json?query=" + encodedQuery +
+                "&display=" + display + "&start=" + start;
+
+        log.info("네이버 쇼핑 API 요청 시작: query='{}'", query);
+        log.debug("요청 URL: {}", url);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<JsonNode> response = restTemplate.exchange(
+                URI.create(url), HttpMethod.GET, entity, JsonNode.class
+        );
+        log.info("네이버 응답 상태 코드: {}", response.getStatusCode());
+
+        JsonNode body = response.getBody();
+        log.debug("네이버 응답 바디: {}", body);
+
+        JsonNode items = body.get("items");
+
+        if (items == null || !items.isArray()) {
+            log.warn("items 노드가 없거나 배열이 아님. 전체 응답: {}", body);
+            return List.of();
+        }
+
+        List<ProductResponseDto> result = new ArrayList<>();
+        for (JsonNode item : items) {
+            result.add(new ProductResponseDto(
+                    null,
+                    item.get("title").asText(),
+                    item.get("link").asText(),
+                    item.get("image").asText(),
+                    item.get("lprice").asInt(),
+                    item.get("mallName").asText()
+            ));
+        }
+
+        log.info("파싱된 상품 수: {}", result.size());
+        return result;
+    }
+}
+

--- a/src/main/java/com/example/giftrecommender/service/ProductImportService.java
+++ b/src/main/java/com/example/giftrecommender/service/ProductImportService.java
@@ -4,66 +4,128 @@ import com.example.giftrecommender.domain.entity.Product;
 import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
 import com.example.giftrecommender.domain.repository.ProductRepository;
 import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
-import com.example.giftrecommender.infra.coupang.CoupangApiClient;
-import com.example.giftrecommender.infra.coupang.dto.CoupangProductResponseDto;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.example.giftrecommender.infra.naver.NaverApiClient;
+import com.example.giftrecommender.util.RecommendationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductImportService {
 
-    private final CoupangApiClient coupangApiClient;
+    private final NaverApiClient naverApiClient;
     private final ProductRepository productRepository;
     private final KeywordGroupRepository keywordGroupRepository;
+    private static final int MAX_COMBOS = 50;
 
     @Transactional
-    public void importUntilEnough(String queryKeyword, String mainKeyword, int neededCount) {
-        if (queryKeyword == null || queryKeyword.isBlank()) {
-            log.warn("상품 가져오기 실패: 키워드 없음");
+    public void importUntilEnough(List<String> tagKeywords, String priceKeyword, String receiverKeyword,
+                                  String reasonKeyword, int neededCount) {
+        if (tagKeywords == null || tagKeywords.size() < 2) {
+            log.warn("태그 키워드는 2개 이상 필요합니다.");
             return;
         }
 
-        KeywordGroup keywordGroup = keywordGroupRepository.findByMainKeyword(mainKeyword)
-                .orElseGet(() -> keywordGroupRepository.save(new KeywordGroup(mainKeyword)));
+        // 1. KeywordGroup 미리 저장
+        List<String> allKeywords = new ArrayList<>(tagKeywords);
+        if (!receiverKeyword.isBlank()) allKeywords.add(receiverKeyword);
+        if (!reasonKeyword.isBlank())   allKeywords.add(reasonKeyword);
 
-        log.info("쿠팡 API 단일 페이지 호출 (페이지=1): '{}'", queryKeyword);
+        List<KeywordGroup> groups = keywordGroupRepository.findByMainKeywordIn(allKeywords);
+        Set<String> exist = groups.stream()
+                .map(KeywordGroup::getMainKeyword)
+                .collect(Collectors.toSet());
 
-        List<CoupangProductResponseDto> response = coupangApiClient.searchProducts(queryKeyword, 1);
+        List<KeywordGroup> newGroups = allKeywords.stream()
+                .filter(k -> !exist.contains(k))
+                .map(KeywordGroup::new)
+                .toList();
 
-        int saveProduct = 0;
-        for (CoupangProductResponseDto dto : response) {
-            long coupangId = dto.coupangProductId();
+        keywordGroupRepository.saveAll(newGroups);
+        groups.addAll(newGroups);
 
-            if (productRepository.existsByCoupangProductId(coupangId)) {
-                log.debug("중복 저장 스킵(DB): {}", coupangId);
-                continue;
-            }
+        // 2. 우선순위 콤보 생성
+        List<List<String>> combos = RecommendationUtil.generatePriorityCombos(tagKeywords, receiverKeyword, reasonKeyword);
 
-            Product p = Product.builder()
-                    .productUrl(UUID.randomUUID().toString())
-                    .coupangProductId(coupangId)
-                    .title(dto.title())
-                    .price(dto.price())
-                    .imageUrl(dto.imageUrl())
-                    .productUrl(dto.productUrl())
-                    .rank(dto.rank())
-                    .isRocket(dto.isRocket())
-                    .isFreeShipping(dto.isFreeShipping())
-                    .keywordGroups(List.of(keywordGroup))
-                    .build();
-            productRepository.save(p);
-            saveProduct++;
+        Set<String> searched = new HashSet<>();
+        Set<String> seenTitles = new HashSet<>();
+        List<Product> toSave = new ArrayList<>();
+        Map<String, Product> priceFilteredBrandMap = new LinkedHashMap<>();
 
-            if (saveProduct >= neededCount) break;
+        if (combos.size() > MAX_COMBOS) {
+            combos = combos.subList(0, MAX_COMBOS);
         }
 
-        log.info("단일 페이지 수집 완료: {}개 (목표={})", saveProduct, neededCount);
-    }
-}
+        for (List<String> combo : combos) {
+            String query = String.join(" ", combo);
+            if (!searched.add(query)) continue;
 
+            log.info("검색 콤보: '{}'", query);
+            for (int page = 1; page <= 10; page++) {
+                log.info("API 호출: '{}', page={}", query, page);
+                List<ProductResponseDto> items = naverApiClient.search(query, page, 100);
+                if (items.isEmpty()) break;
+
+                Set<String> links = items.stream()
+                        .map(ProductResponseDto::link)
+                        .collect(Collectors.toSet());
+                Set<String> existingLinks = productRepository.findLinksIn(links);
+
+                for (ProductResponseDto dto : items) {
+                    // 이미 DB에 있는 링크면 skip
+                    if (existingLinks.contains(dto.link())) continue;
+
+                    //  제목이 이미 처리된 적 있으면 skip
+                    if (!seenTitles.add(dto.title())) continue;
+
+                    List<KeywordGroup> matched = groups.stream()
+                            .filter(g -> combo.contains(g.getMainKeyword()))
+                            .toList();
+
+                    Product p = Product.from(dto, matched);
+                    toSave.add(p);
+
+                    if (matchesPrice(p.getPrice(), priceKeyword)) {
+                        log.info("가격 필터 통과: {}", p.getPrice());
+
+                        String brand = RecommendationUtil.extractBrand(p.getTitle(), p.getMallName());
+                        priceFilteredBrandMap.putIfAbsent(brand, p);
+
+                        if (priceFilteredBrandMap.size() >= neededCount) {
+                            productRepository.saveAll(toSave);
+                            log.info("저장 완료 - 브랜드 필터 통과: {}, 가격 필터 통과: {}",
+                                    priceFilteredBrandMap.size(), countPriceMatched(toSave, priceKeyword));
+                            return;
+                        }
+                    }
+                }
+                if (items.size() < 100) break;
+            }
+        }
+    }
+
+    private long countPriceMatched(List<Product> products, String priceKeyword) {
+        return products.stream().filter(p -> matchesPrice(p.getPrice(), priceKeyword)).count();
+    }
+
+    private boolean matchesPrice(int price, String priceKeyword) {
+        return switch (priceKeyword) {
+            case "1만원 이하" -> price <= 10_000;
+            case "1~3만원"   -> price >= 10_000 && price <= 30_000;
+            case "3~5만원"   -> price >= 30_000 && price <= 50_000;
+            case "5~10만원"  -> price >= 50_000 && price <= 100_000;
+            case "10~30만원" -> price >= 100_000 && price <= 300_000;
+            case "30~50만원" -> price >= 300_000 && price <= 500_000;
+            default          -> false;
+        };
+    }
+
+
+}

--- a/src/main/java/com/example/giftrecommender/service/RecommendationService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationService.java
@@ -2,20 +2,20 @@ package com.example.giftrecommender.service;
 
 import com.example.giftrecommender.common.exception.ErrorException;
 import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
 import com.example.giftrecommender.domain.entity.*;
 import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
 import com.example.giftrecommender.domain.repository.*;
-import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
 import com.example.giftrecommender.dto.response.RecommendationResponseDto;
 import com.example.giftrecommender.dto.response.RecommendedProductResponseDto;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.giftrecommender.util.RecommendationUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -27,108 +27,189 @@ public class RecommendationService {
     private final ProductRepository productRepository;
     private final RecommendationResultRepository resultRepository;
     private final RecommendationProductRepository recommendationProductRepository;
-    private final KeywordGroupRepository keywordGroupRepository;
     private final ProductImportService productService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RedisQuotaManager quotaManager;
 
     @Transactional
     public RecommendationResponseDto recommend(UUID guestId, UUID sessionId, List<String> keywords) {
         Guest guest = existsGuest(guestId);
         RecommendationSession session = existsRecommendationSession(sessionId);
+        verifySessionOwner(session, guest);
 
-        // 가격 필터 분리
-        String priceFilter = keywords.stream()
-                .filter(k -> k.contains("이하") || k.contains("이상"))
-                .findFirst()
-                .orElse("전체");
-
+        // 1. 키워드 분류
+        String priceKeyword = keywords.stream().filter(k -> k.contains("만원")).findFirst().orElse("전체");
+        String receiverKeyword = keywords.stream()
+                .filter(k -> List.of("친구","남자친구","여자친구","엄마","아빠","남자 동료","여자 동료").contains(k))
+                .findFirst().orElse("");
+        String reasonKeyword = keywords.stream()
+                .filter(k -> List.of("생일","기념일","감사","위로","응원","일상 선물").contains(k))
+                .findFirst().orElse("");
         List<String> tagKeywords = keywords.stream()
-                .filter(k -> !k.contains("이하") && !k.contains("이상"))
-                .toList();
+                .filter(k -> !k.equals(priceKeyword) && !k.equals(receiverKeyword) && !k.equals(reasonKeyword))
+                .collect(Collectors.toList());
 
-        // 전체 키워드 문자열로 조합
-        String combinedKeyword = String.join(" ", tagKeywords);
-        String keywordJson = toJson(keywords);
+        log.info("대상: {}, 가격: {}, 이유: {}, 태그: {}", receiverKeyword, priceKeyword, reasonKeyword, tagKeywords);
 
-        // 1. DB에서 먼저 조회
-        List<Product> products = productRepository.findByKeyword(combinedKeyword);
-        List<Product> allCandidates = new ArrayList<>(products);
-
-        // 2. 충분하지 않으면 외부 API 호출 후 저장
-        if (products.size() < 4) {
-            log.info("{} 키워드로 DB에 부족하여 외부 API 호출", combinedKeyword);
-            productService.importUntilEnough(combinedKeyword, combinedKeyword, 4);
-            List<Product> newProducts = productRepository.findByKeyword(combinedKeyword);
-            allCandidates.addAll(newProducts);
-        } else {
-            log.info("{} 키워드로 DB에 충분한 상품이 있어 API 생략", combinedKeyword);
+        // 2. 가격 필터 설정
+        int minPrice = 0, maxPrice = Integer.MAX_VALUE;
+        switch (priceKeyword) {
+            case "1만원 이하" -> maxPrice = 10_000;
+            case "1~3만원" -> { minPrice = 10_000; maxPrice = 30_000; }
+            case "3~5만원" -> { minPrice = 30_000; maxPrice = 50_000; }
+            case "5~10만원" -> { minPrice = 50_000; maxPrice = 100_000; }
+            case "10~30만원" -> { minPrice = 100_000; maxPrice = 300_000; }
+            case "30~50만원" -> { minPrice = 300_000; maxPrice = 500_000; }
         }
 
-        // 중복 제거 후 가격 및 태그 필터링
-        List<Product> filtered = allCandidates.stream()
-                .distinct()
-                .filter(p -> matchesPrice(p.getPrice(), priceFilter))
-                .filter(p -> matchesTags(p.getKeywordGroups(), tagKeywords))
-                .limit(4)
-                .toList();
+        // 3. 키워드 우선순위 조합 생성
+        List<List<String>> combos = RecommendationUtil.generatePriorityCombos(tagKeywords, receiverKeyword, reasonKeyword);
 
+        // 4. DB 조회 시도
+        List<Product> finalProducts = findBestMatched(combos, minPrice, maxPrice);
+
+        // 5. 조합 키워드 누락 또는 결과 부족 시 외부 API 보강
+        boolean keywordMismatch = !finalProducts.isEmpty() && !containsAllComboKeywords(finalProducts, combos.get(0));
+        if (finalProducts.size() < 4 || keywordMismatch) {
+            if (!quotaManager.canCall()) {
+                throw new ErrorException(ExceptionEnum.QUOTA_EXCEEDED);
+            }
+            productService.importUntilEnough(tagKeywords, priceKeyword, receiverKeyword, reasonKeyword, 4);
+            finalProducts = findBestMatched(combos, minPrice, maxPrice);
+        }
+
+        log.info("추천 상품 {}개", finalProducts.size());
+        finalProducts.forEach(p ->
+                log.info("{} | {}원 | 태그={}", p.getTitle(), p.getPrice(),
+                        p.getKeywordGroups().stream().map(KeywordGroup::getMainKeyword).toList()));
+
+        // 6. 결과 저장
         RecommendationResult result = resultRepository.save(RecommendationResult.builder()
                 .guest(guest)
                 .recommendationSession(session)
-                .keywords(keywordJson)
+                .keywords(keywords)
                 .build());
 
-        List<RecommendationProduct> recProducts = filtered.stream()
+        List<RecommendationProduct> recs = finalProducts.stream()
                 .map(p -> new RecommendationProduct(result, p))
                 .toList();
-        recommendationProductRepository.saveAll(recProducts);
+        recommendationProductRepository.saveAll(recs);
 
         return new RecommendationResponseDto(
-                filtered.stream().map(RecommendedProductResponseDto::from).toList()
+                session.getName(),
+                finalProducts.stream().map(RecommendedProductResponseDto::from).toList()
         );
     }
 
-    private Guest existsGuest(UUID guestId) {
-        return guestRepository.findById(guestId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND)
+    @Transactional(readOnly = true)
+    public RecommendationResponseDto getRecommendationResult(UUID guestId, UUID sessionId) {
+        Guest guest = existsGuest(guestId);
+        RecommendationSession session = existsRecommendationSession(sessionId);
+        verifySessionOwner(session, guest);
+
+        RecommendationResult result = resultRepository.findByRecommendationSessionId(sessionId)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.RESULT_NOT_FOUND));
+
+        List<Product> products = recommendationProductRepository.findProductsByResultId(result.getId());
+
+        return new RecommendationResponseDto(
+                result.getRecommendationSession().getName(),
+                products.stream().map(RecommendedProductResponseDto::from).toList()
         );
     }
 
-    private RecommendationSession existsRecommendationSession(UUID sessionId) {
-        return sessionRepository.findById(sessionId).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND)
-        );
+    private List<Product> findBestMatched(List<List<String>> combos, int minPrice, int maxPrice) {
+        for (List<String> combo : combos) {
+            List<Product> candidates = productRepository.findTopByTagsAndPriceRange(combo, minPrice, maxPrice);
+            Set<String> comboSet = new HashSet<>(combo);
+
+            // 1. 완전 일치 (키워드 동일)
+            List<Product> exactMatch = candidates.stream()
+                    .filter(p -> {
+                        Set<String> keywords = p.getKeywordGroups().stream()
+                                .map(KeywordGroup::getMainKeyword)
+                                .collect(Collectors.toSet());
+                        return keywords.equals(comboSet);
+                    })
+                    .toList();
+            List<Product> exactDistinct = pickDistinctBrandsExactly(exactMatch, 4);
+            if (!exactDistinct.isEmpty()) return exactDistinct;
+
+            // 2. 완전 포함 (모든 키워드 포함) && 태그 수 작거나 같음
+            List<Product> partialMatch = candidates.stream()
+                    .filter(p -> {
+                        Set<String> keywords = p.getKeywordGroups().stream()
+                                .map(KeywordGroup::getMainKeyword)
+                                .collect(Collectors.toSet());
+                        return keywords.containsAll(comboSet) && keywords.size() <= comboSet.size();
+                    })
+                    .toList();
+            List<Product> partialDistinct = pickDistinctBrandsExactly(partialMatch, 4);
+            if (!partialDistinct.isEmpty()) return partialDistinct;
+
+            // 3. 유사도 70% 이상 && 태그 수 작거나 같음
+            List<Product> relaxedMatch = candidates.stream()
+                    .filter(p -> {
+                        Set<String> keywords = p.getKeywordGroups().stream()
+                                .map(KeywordGroup::getMainKeyword)
+                                .collect(Collectors.toSet());
+                        long matchedCount = comboSet.stream().filter(keywords::contains).count();
+                        double similarity = matchedCount / (double) comboSet.size();
+                        return similarity >= 0.7 && keywords.size() <= comboSet.size();
+                    })
+                    .toList();
+            List<Product> relaxedDistinct = pickDistinctBrandsExactly(relaxedMatch, 4);
+            if (!relaxedDistinct.isEmpty()) return relaxedDistinct;
+        }
+
+        return Collections.emptyList();
     }
 
-    private String toJson(List<String> keywords) {
-        try {
-            return objectMapper.writeValueAsString(keywords);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("JSON 변경 실패", e);
+    private boolean containsAllComboKeywords(List<Product> products, List<String> combo) {
+        Set<String> totalKeywords = products.stream()
+                .flatMap(p -> p.getKeywordGroups().stream())
+                .map(KeywordGroup::getMainKeyword)
+                .collect(Collectors.toSet());
+
+        Set<String> comboSet = new HashSet<>(combo);
+        Set<String> missing = comboSet.stream()
+                .filter(k -> !totalKeywords.contains(k))
+                .collect(Collectors.toSet());
+
+        log.debug("총 키워드: {}", totalKeywords);
+        log.debug("요청 콤보: {}", comboSet);
+        log.debug("누락 키워드: {}", missing);
+
+        return totalKeywords.containsAll(combo);
+    }
+
+    private List<Product> pickDistinctBrandsExactly(List<Product> products, int needCount) {
+        Map<String, Product> brandMap = new LinkedHashMap<>();
+
+        for (Product p : products) {
+            String brand = RecommendationUtil.extractBrand(p.getTitle(), p.getMallName());
+            if (!brandMap.containsKey(brand)) {
+                brandMap.put(brand, p);
+            }
+            if (brandMap.size() > needCount) break;
+        }
+
+        return brandMap.size() == needCount ? new ArrayList<>(brandMap.values()) : Collections.emptyList();
+    }
+
+
+    private Guest existsGuest(UUID id) {
+        return guestRepository.findById(id)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.GUEST_NOT_FOUND));
+    }
+
+    private RecommendationSession existsRecommendationSession(UUID id) {
+        return sessionRepository.findById(id)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.SESSION_NOT_FOUND));
+    }
+
+    private static void verifySessionOwner(RecommendationSession session, Guest guest) {
+        if (!session.getGuest().getId().equals(guest.getId())) {
+            throw new ErrorException(ExceptionEnum.SESSION_FORBIDDEN);
         }
     }
-
-    private boolean matchesPrice(int price, String priceFilter) {
-        return switch (priceFilter) {
-            case "5만원 이하" -> price <= 50000;
-            case "5만원 이상 10만원 이하" -> price >= 50000 && price <= 100000;
-            case "10만원 이상 20만원 이하" -> price >= 100000 && price <= 200000;
-            case "20만원 이상" -> price >= 200000;
-            default -> true;
-        };
-    }
-
-    private boolean matchesTags(List<KeywordGroup> keywordGroups, List<String> tagKeywords) {
-        List<String> productTags = keywordGroups.stream()
-                .map(KeywordGroup::getMainKeyword)
-                .toList();
-
-        long matchCount = tagKeywords.stream()
-                .filter(productTags::contains)
-                .count();
-
-        return matchCount >= Math.ceil(tagKeywords.size() / 2.0);
-    }
-
-
 }

--- a/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationSessionService.java
@@ -36,7 +36,10 @@ public class RecommendationSessionService {
                 .build();
 
         recommendationSessionRepository.save(recommendationSession);
-        return new RecommendationSessionResponseDto(recommendationSession.getId());
+        return new RecommendationSessionResponseDto(
+                recommendationSession.getId(),
+                recommendationSession.getName()
+        );
     }
 
 }

--- a/src/main/java/com/example/giftrecommender/util/RecommendationUtil.java
+++ b/src/main/java/com/example/giftrecommender/util/RecommendationUtil.java
@@ -1,0 +1,86 @@
+package com.example.giftrecommender.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecommendationUtil {
+
+    // 브랜드 추출
+    public static String extractBrand(String title, String mallName) {
+        String lower = title.toLowerCase();
+        if (lower.contains("삼성")) return "삼성";
+        if (lower.contains("apple") || lower.contains("애플")) return "애플";
+        if (lower.contains("sony") || lower.contains("소니")) return "소니";
+        if (lower.contains("lg")) return "LG";
+        return mallName;
+    }
+
+    /*
+     * receiver(예: “여자친구”)
+     * reason(예: “생일”, “기념일”)
+     * tags(예: “우아한”, “악세서리”, “목걸이”)
+     * 1) [tags(r개) + receiver + reason]
+     * 2) [tags(r개) + receiver]
+     * 3) [tags(r개) + reason]
+     * 4) [tags(r개)]
+     * 순서로 내림차순(r = tags.size() → 2) 조합 생성
+     */
+    public static List<List<String>> generatePriorityCombos(List<String> tags, String receiver, String reason) {
+        List<List<String>> result = new ArrayList<>();
+        int n = tags.size();
+
+        // 태그 조합 (r개씩 - 가장 구체적인 것부터)
+        for (int r = n; r >= 2; r--) {
+            comboRec(tags, 0, r, new ArrayList<>(), result, receiver, reason);
+        }
+
+        // 태그가 1개뿐인 경우도 보장 (예외적 상황)
+        if (n == 1) {
+            comboRec(tags, 0, 1, new ArrayList<>(), result, receiver, reason);
+        }
+
+        // 마지막 fallback: 대상자 + 이유 (태그 없이)
+        if (tags.size() <= 1 && !receiver.isBlank() && !reason.isBlank()) {
+            result.add(List.of(receiver, reason));
+        }
+
+        return result;
+    }
+
+    private static void comboRec(List<String> tags, int start, int r, List<String> cur,
+                          List<List<String>> out, String receiver, String reason) {
+        if (cur.size() == r) {
+            // 1) 태그 + 대상자 + 이유
+            if (!receiver.isBlank() && !reason.isBlank()) {
+                List<String> combo = new ArrayList<>(cur);
+                combo.add(receiver);
+                combo.add(reason);
+                out.add(combo);
+            }
+
+            // 2) 태그 + 대상자
+            if (!receiver.isBlank()) {
+                List<String> combo = new ArrayList<>(cur);
+                combo.add(receiver);
+                out.add(combo);
+            }
+
+            // 3) 태그 + 이유
+            if (!reason.isBlank()) {
+                List<String> combo = new ArrayList<>(cur);
+                combo.add(reason);
+                out.add(combo);
+            }
+
+            // 4) 태그만
+            out.add(new ArrayList<>(cur));
+            return;
+        }
+
+        for (int i = start; i < tags.size(); i++) {
+            cur.add(tags.get(i));
+            comboRec(tags, i + 1, r, cur, out, receiver, reason);
+            cur.remove(cur.size() - 1);
+        }
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/gift_recommendation?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:mysql://3.39.239.7:3306/gift_recommendation?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: song
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+spring-doc:
+  swagger-ui:
+    enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,8 @@
 spring:
   profiles:
     include: secret
-  datasource:
-    url: jdbc:mysql://localhost:3306/gift_recommendation?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: root
-    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
-    hibernate:
-      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 💡 주요 기능 구현 내역
### 네이버 쇼핑 API 연동
- NaverApiClient 구현을 통해 네이버 쇼핑 API 연동
- 상품 수집 시 쿼터 제한 관리를 위한 `RedisQuotaManager` 추가 (Guava RateLimiter 포함)

### Product 및 추천 조회 기능
- Product 엔티티를 네이버 상품 구조에 맞게 리팩토링
- 가격 + 키워드 기반 상품 조회 쿼리 추가
- 추천 결과 ID 및 세션 ID 기반 상품 조회 기능 추가

### 추천 시스템 고도화
- 추천 결과를 구성하는 `RecommendationUtil` 생성
  - 브랜드/키워드 조합 기반 정제 로직 구현
- 추천 결과 조회 API 구현 (/recommendations/{sessionId})

### DTO 및 응답 구조 개선
- `ProductResponseDto` 생성
- 추천 응답 DTO 구조 및 필드명 정리
- 추천 세션 생성 응답에 name 필드 추가 -> 개인화 문구 활용 가능

## 기타 구조 개선 및 설정
- `domain` 레이어 Instant 필드 적용 및 연관 관계 LAZY 설정 반영
- 환경별 설정 분리 (`application.yml`, `application-local.yml`, `application-prod.yml` 구조 정리)
- 예외 코드 (`QUOTA_EXCEEDED`, `RESULT_NOT_FOUND`, `SESSION_FORBIDDEN`) 추가
- 스케줄링 기능 설정 클래스 추가
- Swagger 예시 키워드 목록 보완

##  참고 사항
- 기존 쿠팡 API 기반 수집 로직은 모두 제거하고 네이버 API 기반으로 전면 교체