### PR TITLE
feat: Swagger HTTPS 인식 및 연동 위한 설정 추가

### DIFF
--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.example.giftrecommender.config;
 import com.example.giftrecommender.common.logging.interceptor.ResponseLoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,6 +16,15 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://mumusgiftbox.o-r.kr")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,3 +10,6 @@ spring:
 spring-doc:
   swagger-ui:
     enabled: true
+
+server:
+  forward-headers-strategy: framework


### PR DESCRIPTION
## 변경 내용
- Spring Boot에서 Nginx 프록시 헤더를 인식하도록 `forward-headers-strategy: framework` 설정 추가
- CORS 설정을 통해 프론트엔드 도메인(`https://mumusgiftbox.o-r.kr`)의 요청을 허용

## 목적
- Swagger UI에서 Generated URL이 http로 뜨는 문제 해결
- HTTPS 환경과 연동 시 CORS 오류 방지

## 테스트
- Swagger UI 상단 URL이 https로 정상 출력됨
- API 요청이 CORS 오류 없이 성공함