### PR TITLE
test: NaverApiClient 단위 테스트 추가 및 외부 의존성 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,10 @@ jobs:
       - name: Grant execute permission
         run: chmod +x gradlew
 
+      - name: Create application-secret.yml
+        run: |
+          mkdir -p src/main/resources
+          echo "${{ secrets.APPLICATION_SECRET_YML }}" > src/main/resources/application-secret.yml
+
       - name: Build with Gradle
         run: ./gradlew clean build

--- a/src/main/java/com/example/giftrecommender/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
+++ b/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
@@ -26,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NaverApiClient {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final RedisQuotaManager quotaManager;
 
     @Value("${naver.client-id}")

--- a/src/test/java/com/example/giftrecommender/GiftrecommenderApplicationTests.java
+++ b/src/test/java/com/example/giftrecommender/GiftrecommenderApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.giftrecommender;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class GiftrecommenderApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
+++ b/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
@@ -1,0 +1,108 @@
+package com.example.giftrecommender.infra.naver;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+class NaverApiClientTest {
+    static class TestReflection {
+        public static void setField(Object target, String fieldName, Object value) {
+            try {
+                Field f = target.getClass().getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(target, value);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Mock
+    private RedisQuotaManager quotaManager;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private NaverApiClient naverApiClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        TestReflection.setField(naverApiClient, "clientId", "test-client-id");
+        TestReflection.setField(naverApiClient, "clientSecret", "test-client-secret");
+    }
+
+    @DisplayName("네이버 API에서 정상적으로 상품을 파싱한다.")
+    @Test
+    void testSearch_success() throws Exception {
+        // given
+        when(quotaManager.canCall()).thenReturn(true);
+
+        String json = """
+        {
+          "items": [
+            {
+              "title": "테스트 상품",
+              "link": "http://example.com",
+              "image": "http://example.com/image.jpg",
+              "lprice": "12345",
+              "mallName": "테스트몰"
+            }
+          ]
+        }
+        """;
+
+        JsonNode mockResponse = new ObjectMapper().readTree(json);
+
+        ResponseEntity<JsonNode> responseEntity = new ResponseEntity<>(mockResponse, HttpStatus.OK);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(JsonNode.class)))
+                .thenReturn(responseEntity);
+
+        // when
+        List<ProductResponseDto> result = naverApiClient.search("테스트", 1, 10);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).title()).isEqualTo("테스트 상품");
+        assertThat(result.get(0).lprice()).isEqualTo(12345);
+    }
+
+    @DisplayName("쿼터 초과 시 예외가 발생해야 한다.")
+    @Test
+    void testSearch_quotaExceeded() {
+        // given
+        when(quotaManager.canCall()).thenReturn(false);
+
+        // when then
+        assertThatThrownBy(() -> naverApiClient.search("테스트", 1, 10))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.QUOTA_EXCEEDED.getMessage());
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- `NaverApiClient`에 대한 단위 테스트(NaverApiClientTest) 추가
- `RedisQuotaManager`, `RestTemplate`을 `@Mock`으로 주입하여 외부 의존성 제거
- `@Value`로 주입받는 `clientId`, `clientSecret`은 Reflection 유틸(TestReflection)로 수동 세팅
- 실제 프로젝트에서는 `RestTemplate`을 직접 생성하지 않고 빈으로 주입받도록 리팩토링
- `-x test` 제거: CI 환경에서 테스트까지 함께 수행하도록 수정

## 테스트 내용
- 정상적인 검색 요청 시 JSON 응답을 올바르게 파싱하는지 검증
- API 호출 가능 쿼터가 초과된 경우 예외(`ErrorException.QUOTA_EXCEEDED`)가 발생하는지 검증

## 기타
- `@SpringBootTest` 대신 순수 단위 테스트로 성능 및 유지보수성 향상
- CI 파이프라인(GitHub Actions)에서 `-x test` 옵션 제거하여, PR 시점에 단위 테스트도 자동 수행되도록 개선