### PR TITLE
test: Question 및 AnswerOption 리포지토리 단위 테스트 추가

### DIFF
--- a/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.example.giftrecommender.domain.repository.answer_option;
+
+import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.domain.repository.question.QuestionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AnswerOptionRepositoryTest {
+
+    @Autowired
+    private AnswerOptionRepository answerOptionRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private Question question;
+
+    @BeforeEach
+    void setUp() {
+        question = questionRepository.save(
+                Question.builder()
+                        .content("취미는?")
+                        .type(QuestionType.CHOICE)
+                        .order(1)
+                        .build()
+        );
+    }
+
+    @DisplayName("특정 질문 ID에 대한 모든 선택지를 조회할 수 있다")
+    @Test
+    void findAllByQuestionId() {
+        // given
+        AnswerOption a1 = createAnswerOption("운동", "운동", question);
+        AnswerOption a2 = createAnswerOption("독서", "책", question);
+
+        answerOptionRepository.saveAll(List.of(a1, a2));
+
+        // when
+        List<AnswerOption> result = answerOptionRepository.findAllByQuestionId(question.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getQuestion().getId()).isEqualTo(question.getId());
+    }
+
+    private static AnswerOption createAnswerOption(String content, String recommendationKeyword, Question question) {
+        return AnswerOption.builder()
+                .content(content)
+                .recommendationKeyword(recommendationKeyword)
+                .question(question)
+                .build();
+    }
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.example.giftrecommender.domain.repository.question;
+
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @DisplayName("질문을 order 기준으로 오름차순 정렬하여 모두 조회할 수 있다")
+    @Test
+    void findAllByOrderByOrderAsc() {
+        // given
+        Question q1 = createQuestion("질문 1", 2);
+        Question q2 = createQuestion("질문 2", 1);
+        questionRepository.saveAll(List.of(q1, q2));
+
+        // when
+        List<Question> result = questionRepository.findAllByOrderByOrderAsc();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getOrder()).isEqualTo(1);
+        assertThat(result.get(1).getOrder()).isEqualTo(2);
+    }
+
+    private static Question createQuestion(String content, int order) {
+        return Question.builder()
+                .content(content)
+                .type(QuestionType.CHOICE)
+                .order(order)
+                .build();
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- `QuestionRepositoryTest` 추가
  - `findAllByOrderByOrderAsc()` 메서드 테스트
  - `order` 필드를 기준으로 오름차순 정렬이 정상 동작하는지 확인
- `AnswerOptionRepositoryTest` 추가
  - 특정 질문 ID에 대한 선택지를 조회하는 `findAllByQuestionId()` 테스트
- `@BeforeEach`를 통해 질문 데이터를 먼저 저장하고 선택지를 연관 저장

## 테스트 방식
- `@DataJpaTest` + `@AutoConfigureTestDatabase(replace = NONE)` 사용
-> 실제 MySQL 환경에서의 쿼리 실행 결과를 검증
- 각 Repository 메서드가 예상대로 동작하는지 단위 테스트 수준에서 빠르게 피드백