### PR TITLE
추천 API 개선 및 테스트 코드 추가, CORS 설정 업데이트

### DIFF
--- a/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
+++ b/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
@@ -43,8 +43,4 @@ public class RedisQuotaManager {
         log.info("네이버 API 쿼터 초기화 완료");
     }
 
-    public long getCallCount() {
-        String raw = redisTemplate.opsForValue().get(KEY);
-        return raw != null ? Long.parseLong(raw) : 0L;
-    }
 }

--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://mumusgiftbox.o-r.kr")
+                .allowedOrigins("https://mumusgiftbox.o-r.kr", "https://moomus-gift.vercel.app")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
@@ -2,6 +2,7 @@ package com.example.giftrecommender.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ public class RecommendationProduct {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @Builder
     public RecommendationProduct(RecommendationResult recommendationResult, Product product) {
         this.recommendationResult = recommendationResult;
         this.product = product;

--- a/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
@@ -10,5 +10,4 @@ public interface KeywordGroupRepository extends JpaRepository<KeywordGroup, Long
 
     List<KeywordGroup> findByMainKeywordIn(List<String> mainKeywords);
 
-    Optional<KeywordGroup> findByMainKeyword(String mainKeyword);
 }

--- a/src/main/java/com/example/giftrecommender/service/RecommendationService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationService.java
@@ -90,7 +90,10 @@ public class RecommendationService {
                 .build());
 
         List<RecommendationProduct> recs = finalProducts.stream()
-                .map(p -> new RecommendationProduct(result, p))
+                .map(p -> RecommendationProduct.builder()
+                        .recommendationResult(result)
+                        .product(p)
+                        .build())
                 .toList();
         recommendationProductRepository.saveAll(recs);
 

--- a/src/test/java/com/example/giftrecommender/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/RecommendationControllerTest.java
@@ -1,0 +1,115 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.dto.request.RecommendationRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import com.example.giftrecommender.dto.response.RecommendedProductResponseDto;
+import com.example.giftrecommender.service.RecommendationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(RecommendationController.class)
+class RecommendationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private RecommendationService recommendationService;
+
+    private UUID guestId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        guestId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+    }
+
+    @DisplayName("POST /recommendation - 추천 요청 성공")
+    @Test
+    void recommendSuccess() throws Exception {
+        // given
+        RecommendationRequestDto request = new RecommendationRequestDto(
+                List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금")
+        );
+
+        RecommendedProductResponseDto product = new RecommendedProductResponseDto(
+                UUID.randomUUID(),
+                "골드 반지",
+                99000,
+                "https://example.com/product/1",
+                "https://example.com/image.jpg",
+                List.of("악세서리", "반지", "금")
+        );
+
+        RecommendationResponseDto fakeResponse = new RecommendationResponseDto(
+                "테스트",
+                List.of(product)
+        );
+
+        when(recommendationService.recommend(eq(guestId), eq(sessionId), anyList())).thenReturn(fakeResponse);
+
+        // when  then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions/{sessionId}/recommendation", guestId, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("추천 완료"))
+                .andExpect(jsonPath("$.data.name").value("테스트"))
+                .andExpect(jsonPath("$.data.products[0].title").value("골드 반지"))
+                .andExpect(jsonPath("$.data.products[0].price").value(99000))
+                .andExpect(jsonPath("$.data.products[0].link").value("https://example.com/product/1"))
+                .andExpect(jsonPath("$.data.products[0].imageUrl").value("https://example.com/image.jpg"))
+                .andExpect(jsonPath("$.data.products[0].keywords[1]").value("반지"));
+    }
+
+    @DisplayName("GET /recommendation - 추천 결과 조회 성공")
+    @Test
+    void getRecommendationResultSuccess() throws Exception {
+        RecommendedProductResponseDto product = new RecommendedProductResponseDto(
+                UUID.randomUUID(),
+                "골드 반지",
+                99000,
+                "https://example.com/product/1",
+                "https://example.com/image.jpg",
+                List.of("악세서리", "반지", "금")
+        );
+
+        RecommendationResponseDto fakeResponse = new RecommendationResponseDto(
+                "테스트",
+                List.of(product)
+        );
+
+        when(recommendationService.getRecommendationResult(eq(guestId), eq(sessionId))).thenReturn(fakeResponse);
+
+        mockMvc.perform(get("/api/guests/{guestId}/recommendation-sessions/{sessionId}/recommendation", guestId, sessionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("추천 결과 조회 성공"))
+                .andExpect(jsonPath("$.data.name").value("테스트"))
+                .andExpect(jsonPath("$.data.products[0].title").value("골드 반지"))
+                .andExpect(jsonPath("$.data.products[0].price").value(99000))
+                .andExpect(jsonPath("$.data.products[0].link").value("https://example.com/product/1"))
+                .andExpect(jsonPath("$.data.products[0].imageUrl").value("https://example.com/image.jpg"))
+                .andExpect(jsonPath("$.data.products[0].keywords[2]").value("금"));
+    }
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ProductRepositoryTest {
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("가격 범위와 키워드로 상품을 조회할 수 있다.")
+    @Test
+    void findTopByTagsAndPriceRange() {
+        // given
+        KeywordGroup kg = keywordGroupRepository.save(new KeywordGroup("운동"));
+        Product product = createProduct("제목", "링크", "image1", 50000, "mall", List.of(kg));
+        productRepository.save(product);
+
+        // when
+        List<Product> result = productRepository.findTopByTagsAndPriceRange(List.of("운동"), 30000, 60000);
+
+        // then
+        assertThat(result).hasSize(1).extracting(Product::getTitle).contains("제목");
+    }
+
+    @DisplayName("중복 링크 조회 테스트")
+    @Test
+    void findLinksIn() {
+        // given
+        Product p1 = createProduct("제목1", "링크1", "image1", 50000, "mall", List.of());
+        Product p2 = createProduct("제목", "링크2", "image2", 30000, "mall", List.of());
+        productRepository.saveAll(List.of(p1, p2));
+
+        // when
+        Set<String> result = productRepository.findLinksIn(Set.of("링크1", "링크3"));
+
+        // then
+        assertThat(result).containsOnly("링크1");
+    }
+
+    private Product createProduct(String title, String link, String imageUrl, Integer price,
+                                  String mallName, List<KeywordGroup> keywordGroups) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mallName)
+                .keywordGroups(keywordGroups)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/RecommendationProductRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/RecommendationProductRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.*;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecommendationProductRepositoryTest {
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private RecommendationProductRepository recommendationProductRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationProductRepository.deleteAllInBatch();
+        recommendationResultRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("추천 결과 ID로 상품 목록을 조회할 수 있다.")
+    @Test
+    void findProductsByResultId() {
+        // given
+
+        Product product = createProduct("제목", "링크", "image", 10000, "mall");
+        productRepository.save(product);
+
+        RecommendationResult result = createRecommendationResult(guest, recommendationSession);
+        recommendationResultRepository.save(result);
+
+        recommendationProductRepository.save(RecommendationProduct.builder()
+                .recommendationResult(result)
+                .product(product)
+                .build());
+
+        // when
+        List<Product> resultList = recommendationProductRepository.findProductsByResultId(result.getId());
+
+        // then
+        assertThat(resultList).hasSize(1).contains(product);
+    }
+
+    private static RecommendationResult createRecommendationResult(Guest guest, RecommendationSession recommendationSession) {
+        return RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .keywords(List.of())
+                .build();
+    }
+
+    private static Product createProduct(String title, String link, String imageUrl, Integer price, String mallName) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mallName)
+                .keywordGroups(List.of())
+                .build();
+    }
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/RecommendationResultRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/RecommendationResultRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.entity.RecommendationResult;
+import com.example.giftrecommender.domain.entity.RecommendationSession;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecommendationResultRepositoryTest {
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationResultRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("추천 세션 ID로 추천 결과를 조회할 수 있다.")
+    @Test
+    void findByRecommendationSessionId() {
+        // given
+        RecommendationResult recommendationResult = RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .build();
+        recommendationResultRepository.save(recommendationResult);
+
+        // when
+        Optional<RecommendationResult> result =
+                recommendationResultRepository.findByRecommendationSessionId(recommendationSession.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getRecommendationSession().getId()).isEqualTo(recommendationSession.getId());
+    }
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.example.giftrecommender.domain.repository.keyword;
+
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class KeywordGroupRepositoryTest {
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @DisplayName("여러 키워드로 키워드 그룹을 조회할 수 있다.")
+    @Test
+    void findByMainKeywordIn() {
+        // given
+        keywordGroupRepository.save(new KeywordGroup("운동"));
+        keywordGroupRepository.save(new KeywordGroup("건강"));
+
+        // when
+        List<KeywordGroup> results = keywordGroupRepository.findByMainKeywordIn(List.of("운동", "건강", "다이어트"));
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(KeywordGroup::getMainKeyword).contains("운동", "건강");
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.giftrecommender.service;
+
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.repository.ProductRepository;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.example.giftrecommender.infra.naver.NaverApiClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ProductImportServiceTest {
+
+    @Autowired private ProductImportService productImportService;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @MockBean private NaverApiClient naverApiClient;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("상품이 조건에 맞게 저장된다")
+    @Test
+    void importUntilEnoughPriceMatches() {
+        // given
+        List<String> tags = List.of("감성", "우아한");
+        String priceKeyword = "5~10만원";
+        String receiver = "연인";
+        String reason = "생일";
+
+        ProductResponseDto mockDto = new ProductResponseDto(
+                UUID.randomUUID(),
+                "우아한 감성 커플 선물",
+                "https://example.com/product1",
+                "https://example.com/image1.jpg",
+                89000,
+                "쿠팡"
+        );
+
+        when(naverApiClient.search(anyString(), eq(1), eq(100)))
+                .thenReturn(List.of(mockDto));
+        when(naverApiClient.search(anyString(), intThat(i -> i > 1), eq(100)))
+                .thenReturn(List.of());
+
+        // when
+        productImportService.importUntilEnough(tags, priceKeyword, receiver, reason, 1);
+
+        // then
+        List<Product> saved = productRepository.findAll();
+        assertThat(saved).hasSize(1);
+        Product savedProduct = saved.get(0);
+        assertThat(savedProduct.getPrice()).isEqualTo(89000);
+        assertThat(savedProduct.getTitle()).contains("감성");
+        assertThat(savedProduct.getLink()).isEqualTo("https://example.com/product1");
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
@@ -1,0 +1,236 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
+import com.example.giftrecommender.domain.entity.*;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import com.example.giftrecommender.domain.repository.*;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class RecommendationServiceTest {
+
+    @Autowired private RecommendationService recommendationService;
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    @Autowired private RecommendationProductRepository recommendationProductRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @MockBean private RedisQuotaManager redisQuotaManager;
+
+    @MockBean private ProductImportService productImportService;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    private List<Product> products = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+
+        KeywordGroup k1 = new KeywordGroup("연인");
+        KeywordGroup k2 = new KeywordGroup("생일");
+        KeywordGroup k3 = new KeywordGroup("악세서리");
+        KeywordGroup k4 = new KeywordGroup("반지");
+        KeywordGroup k5 = new KeywordGroup("금");
+        keywordGroupRepository.saveAll(List.of(k1, k2, k3, k4, k5));
+
+        for (int i = 1; i <= 4; i++) {
+            products.add(
+                    createProduct(
+                            "악세서리 반지 금 여자친구 생일",
+                            "https://example.com/" + i,
+                            "https://img.com/" + i + ".jpg",
+                            90000,
+                            "브랜드" + i,
+                            List.of(k1, k2, k3, k4, k5))
+            );
+        }
+        productRepository.saveAll(products);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationProductRepository.deleteAllInBatch();
+        recommendationResultRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("조건에 맞는 상품이 있을 경우 추천 결과  4개가 성공적으로 반환된다.")
+    @Test
+    void recommendationResultProductsExist() {
+        // given
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+        when(redisQuotaManager.canCall()).thenReturn(true);
+
+        // when
+        RecommendationResponseDto response =
+                recommendationService.recommend(guest.getId(), recommendationSession.getId(), keywords);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.products()).hasSize(4);
+        assertThat(response.products()).allSatisfy(product ->
+                assertThat(product.title()).contains("반지")
+        );
+    }
+
+    @DisplayName("추천 결과 조회가 정상적으로 동작한다")
+    @Test
+    void getRecommendationResult() {
+        // given
+        RecommendationResult result = recommendationResultRepository.save(RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .keywords(List.of("악세서리", "반지", "금", "여자친구", "생일"))
+                .build());
+
+        recommendationProductRepository.save(
+                RecommendationProduct.builder()
+                        .recommendationResult(result)
+                        .product(products.get(0))
+                        .build()
+        );
+
+        // when
+        RecommendationResponseDto response =
+                recommendationService.getRecommendationResult(guest.getId(), recommendationSession.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("테스트");
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().get(0).title()).contains("반지");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게스트일 경우 예외가 발생한다.")
+    void guestNotFound() {
+        // given
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(UUID.randomUUID(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.GUEST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션일 경우 예외가 발생한다.")
+    void sessionNotFound() {
+        // given
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(guest.getId(), UUID.randomUUID(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.SESSION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("세션 주인이 아닌 경우 예외가 발생한다.")
+    void sessionOwnerInvalid() {
+        // given
+        Guest anotherGuest = guestRepository.save(createGuest());
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(anotherGuest.getId(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.SESSION_FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("쿼터 초과 시 예외가 발생한다.")
+    void quotaExceeded() {
+        // given
+        when(redisQuotaManager.canCall()).thenReturn(false);
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(guest.getId(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.QUOTA_EXCEEDED.getMessage());
+    }
+
+    @Test
+    @DisplayName("추천 결과 조회 시 추천 이력이 없으면 예외가 발생한다.")
+    void recommendationResultNotFound() {
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.getRecommendationResult(guest.getId(), recommendationSession.getId()))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.RESULT_NOT_FOUND.getMessage());
+    }
+
+    private static Product createProduct(String title, String link, String imageUrl,
+                                         Integer price, String mall, List<KeywordGroup> keywordGroups) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mall)
+                .keywordGroups(keywordGroups)
+                .build();
+    }
+
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 주요 변경 사항
- `RecommendationProduct`에 `@Builder` 적용 및 관련 생성 로직 리팩토링
- 추천 API (Service, Controller)에 대한 WebMvcTest 및 단위 테스트 코드 작성
- 상품 조회 조건 기반 `importUntilEnough` 테스트 추가
- Repository 단위 테스트 추가
  - `ProductRepository`: 키워드 및 가격 필터 기반 조회
  - `RecommendationResultRepository`: 세션 ID 기반 조회
  - `RecommendationProductRepository`: 결과 ID 기반 상품 조회
  - `KeywordGroupRepository`: 키워드 목록 조회
- CORS 허용 도메인에 프론트엔드 주소(`vercel.app`) 추가
- 사용되지 않는 `RedisQuotaManager#getCallCount` 메서드 제거

### 목적
- 추천 기능의 신뢰성 향상을 위한 테스트 커버리지 확보
- 실 배포 환경을 고려한 CORS 설정 반영
- 사용되지 않는 코드 정리를 통한 유지보수성 향상