### PR TITLE
추천 기능 신뢰성 향상을 위한 테스트 커버리지 확장 및 빌더 패턴 리팩토링

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,10 @@ jobs:
       - name: Grant execute permission
         run: chmod +x gradlew
 
+      - name: Create application-secret.yml
+        run: |
+          mkdir -p src/main/resources
+          echo "${{ secrets.APPLICATION_SECRET_YML }}" > src/main/resources/application-secret.yml
+
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
 
       - name: Save PEM key to file
         run: |

--- a/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
+++ b/src/main/java/com/example/giftrecommender/common/quota/RedisQuotaManager.java
@@ -43,8 +43,4 @@ public class RedisQuotaManager {
         log.info("네이버 API 쿼터 초기화 완료");
     }
 
-    public long getCallCount() {
-        String raw = redisTemplate.opsForValue().get(KEY);
-        return raw != null ? Long.parseLong(raw) : 0L;
-    }
 }

--- a/src/main/java/com/example/giftrecommender/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://mumusgiftbox.o-r.kr")
+                .allowedOrigins("https://mumusgiftbox.o-r.kr", "https://moomus-gift.vercel.app")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/RecommendationProduct.java
@@ -2,6 +2,7 @@ package com.example.giftrecommender.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,6 +23,7 @@ public class RecommendationProduct {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
+    @Builder
     public RecommendationProduct(RecommendationResult recommendationResult, Product product) {
         this.recommendationResult = recommendationResult;
         this.product = product;

--- a/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepository.java
@@ -10,5 +10,4 @@ public interface KeywordGroupRepository extends JpaRepository<KeywordGroup, Long
 
     List<KeywordGroup> findByMainKeywordIn(List<String> mainKeywords);
 
-    Optional<KeywordGroup> findByMainKeyword(String mainKeyword);
 }

--- a/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
+++ b/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
@@ -26,7 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NaverApiClient {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
     private final RedisQuotaManager quotaManager;
 
     @Value("${naver.client-id}")

--- a/src/main/java/com/example/giftrecommender/service/RecommendationService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationService.java
@@ -90,7 +90,10 @@ public class RecommendationService {
                 .build());
 
         List<RecommendationProduct> recs = finalProducts.stream()
-                .map(p -> new RecommendationProduct(result, p))
+                .map(p -> RecommendationProduct.builder()
+                        .recommendationResult(result)
+                        .product(p)
+                        .build())
                 .toList();
         recommendationProductRepository.saveAll(recs);
 

--- a/src/test/java/com/example/giftrecommender/GiftrecommenderApplicationTests.java
+++ b/src/test/java/com/example/giftrecommender/GiftrecommenderApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.giftrecommender;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class GiftrecommenderApplicationTests {
 
 	@Test

--- a/src/test/java/com/example/giftrecommender/controller/GuestControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/GuestControllerTest.java
@@ -1,0 +1,44 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.dto.response.GuestResponseDto;
+import com.example.giftrecommender.service.GuestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(GuestController.class)
+class GuestControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private GuestService guestService;
+
+    @DisplayName("POST /guests - 비회원 세션 생성 성공")
+    @Test
+    void createGuestSuccess() throws Exception {
+        // given
+        UUID testId = UUID.randomUUID();
+        GuestResponseDto fakeResponse = new GuestResponseDto(testId);
+
+        when(guestService.createGuest()).thenReturn(fakeResponse);
+
+        // when  then
+        mockMvc.perform(post("/api/guests"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비회원 세션 생성 완료."))
+                .andExpect(jsonPath("$.data.guestId").value(testId.toString()));
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/controller/QuestionControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/QuestionControllerTest.java
@@ -1,0 +1,63 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.dto.response.AnswerOptionResponseDto;
+import com.example.giftrecommender.dto.response.QuestionResponseDto;
+import com.example.giftrecommender.service.QuestionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(QuestionController.class)
+class QuestionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private QuestionService questionService;
+
+    @DisplayName("GET /questions - 질문 목록 조회 성공")
+    @Test
+    void getQuestionsSuccess() throws Exception {
+        // given
+        List<AnswerOptionResponseDto> optionList = List.of(
+                new AnswerOptionResponseDto(1L,"연인", "연인"),
+                new AnswerOptionResponseDto(2L, "부모님", "부모님")
+        );
+
+        List<QuestionResponseDto> fakeResponse = List.of(
+                new QuestionResponseDto(
+                        1L,
+                        "누구에게 선물하나요?",
+                        QuestionType.CHOICE,
+                        1,
+                        optionList
+                )
+        );
+
+        when(questionService.getAllQuestion()).thenReturn(fakeResponse);
+
+        // when  then
+        mockMvc.perform(get("/api/questions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("질문 목록 조회 성공"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].content").value("누구에게 선물하나요?"))
+                .andExpect(jsonPath("$.data[0].type").value("CHOICE"))
+                .andExpect(jsonPath("$.data[0].order").value(1))
+                .andExpect(jsonPath("$.data[0].options[0].content").value("연인"))
+                .andExpect(jsonPath("$.data[0].options[0].recommendationKeyword").value("연인"));
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/controller/RecommendationControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/RecommendationControllerTest.java
@@ -1,0 +1,115 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.dto.request.RecommendationRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import com.example.giftrecommender.dto.response.RecommendedProductResponseDto;
+import com.example.giftrecommender.service.RecommendationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(RecommendationController.class)
+class RecommendationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private RecommendationService recommendationService;
+
+    private UUID guestId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        guestId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+    }
+
+    @DisplayName("POST /recommendation - 추천 요청 성공")
+    @Test
+    void recommendSuccess() throws Exception {
+        // given
+        RecommendationRequestDto request = new RecommendationRequestDto(
+                List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금")
+        );
+
+        RecommendedProductResponseDto product = new RecommendedProductResponseDto(
+                UUID.randomUUID(),
+                "골드 반지",
+                99000,
+                "https://example.com/product/1",
+                "https://example.com/image.jpg",
+                List.of("악세서리", "반지", "금")
+        );
+
+        RecommendationResponseDto fakeResponse = new RecommendationResponseDto(
+                "테스트",
+                List.of(product)
+        );
+
+        when(recommendationService.recommend(eq(guestId), eq(sessionId), anyList())).thenReturn(fakeResponse);
+
+        // when  then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions/{sessionId}/recommendation", guestId, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("추천 완료"))
+                .andExpect(jsonPath("$.data.name").value("테스트"))
+                .andExpect(jsonPath("$.data.products[0].title").value("골드 반지"))
+                .andExpect(jsonPath("$.data.products[0].price").value(99000))
+                .andExpect(jsonPath("$.data.products[0].link").value("https://example.com/product/1"))
+                .andExpect(jsonPath("$.data.products[0].imageUrl").value("https://example.com/image.jpg"))
+                .andExpect(jsonPath("$.data.products[0].keywords[1]").value("반지"));
+    }
+
+    @DisplayName("GET /recommendation - 추천 결과 조회 성공")
+    @Test
+    void getRecommendationResultSuccess() throws Exception {
+        RecommendedProductResponseDto product = new RecommendedProductResponseDto(
+                UUID.randomUUID(),
+                "골드 반지",
+                99000,
+                "https://example.com/product/1",
+                "https://example.com/image.jpg",
+                List.of("악세서리", "반지", "금")
+        );
+
+        RecommendationResponseDto fakeResponse = new RecommendationResponseDto(
+                "테스트",
+                List.of(product)
+        );
+
+        when(recommendationService.getRecommendationResult(eq(guestId), eq(sessionId))).thenReturn(fakeResponse);
+
+        mockMvc.perform(get("/api/guests/{guestId}/recommendation-sessions/{sessionId}/recommendation", guestId, sessionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("추천 결과 조회 성공"))
+                .andExpect(jsonPath("$.data.name").value("테스트"))
+                .andExpect(jsonPath("$.data.products[0].title").value("골드 반지"))
+                .andExpect(jsonPath("$.data.products[0].price").value(99000))
+                .andExpect(jsonPath("$.data.products[0].link").value("https://example.com/product/1"))
+                .andExpect(jsonPath("$.data.products[0].imageUrl").value("https://example.com/image.jpg"))
+                .andExpect(jsonPath("$.data.products[0].keywords[2]").value("금"));
+    }
+}

--- a/src/test/java/com/example/giftrecommender/controller/RecommendationSessionControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/RecommendationSessionControllerTest.java
@@ -1,0 +1,65 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
+import com.example.giftrecommender.service.RecommendationSessionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(RecommendationSessionController.class)
+class RecommendationSessionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private RecommendationSessionService recommendationSessionService;
+
+    private UUID guestId;
+
+    @BeforeEach
+    void setUp() {
+        guestId = UUID.randomUUID();
+    }
+
+    @DisplayName("POST /recommendation-sessions - 추천 세션 생성 성공")
+    @Test
+    void createRecommendationSessionSuccess() throws Exception {
+        // given
+        UUID testSessionId = UUID.randomUUID();
+
+        RecommendationSessionRequestDto request = new RecommendationSessionRequestDto("테스트");
+
+        RecommendationSessionResponseDto fakeResponse = new RecommendationSessionResponseDto(
+                testSessionId,
+                request.name()
+        );
+
+        when(recommendationSessionService.createRecommendationSession(guestId, request)).thenReturn(fakeResponse);
+
+        // when  then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions", guestId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("추천 세션 등록"))
+                .andExpect(jsonPath("$.data.name").value("테스트"));
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/controller/UserAnswerAiControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/UserAnswerAiControllerTest.java
@@ -1,0 +1,71 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.dto.request.AnswerOptionRequestDto;
+import com.example.giftrecommender.dto.request.QuestionRequestDto;
+import com.example.giftrecommender.dto.request.UserAnswerAiRequestDto;
+import com.example.giftrecommender.service.UserAnswerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(UserAnswerAiController.class)
+class UserAnswerAiControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private UserAnswerService userAnswerService;
+
+    private UUID guestId;
+
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        guestId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+    }
+
+    @DisplayName("POST /ai-answers - GPT 기반 질문/선택지/답변 저장 성공")
+    @Test
+    void saveAiQuestionSuccess() throws Exception {
+        // given
+        QuestionRequestDto question = new QuestionRequestDto("연인의 취미가 뭐야?", QuestionType.CHOICE, 4);
+        List<AnswerOptionRequestDto> options = List.of(
+                new AnswerOptionRequestDto("캠핑", "야외활동"),
+                new AnswerOptionRequestDto("운동", "건강"),
+                new AnswerOptionRequestDto("영화", "문화생활")
+        );
+        int selectedIndex = 1;
+
+        UserAnswerAiRequestDto requestDto = new UserAnswerAiRequestDto(question, options, selectedIndex);
+
+        doNothing().when(userAnswerService).saveAiQuestionAndAnswer(guestId, sessionId, requestDto);
+
+        // when & then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions/{sessionId}/ai-answers", guestId, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("AI 질문, 선택지 저장 완료 및 유저 응답 완료"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/controller/UserAnswerControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/UserAnswerControllerTest.java
@@ -1,0 +1,61 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.dto.request.UserAnswerRequestDto;
+import com.example.giftrecommender.service.UserAnswerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ActiveProfiles("test")
+@WebMvcTest(UserAnswerController.class)
+class UserAnswerControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean private UserAnswerService userAnswerService;
+
+    private UUID guestId;
+
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        guestId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+    }
+
+    @DisplayName("POST /answers - 유저 응답 저장 성공")
+    @Test
+    void saveUserAnswerSuccess() throws Exception {
+        // given
+        UserAnswerRequestDto requestDto = new UserAnswerRequestDto(1L, QuestionType.CHOICE,1L);
+        doNothing().when(userAnswerService).saveAnswer(guestId, sessionId, requestDto);
+
+        // when & then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions/{sessionId}/answers", guestId, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("응답 저장"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ProductRepositoryTest {
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("가격 범위와 키워드로 상품을 조회할 수 있다.")
+    @Test
+    void findTopByTagsAndPriceRange() {
+        // given
+        KeywordGroup kg = keywordGroupRepository.save(new KeywordGroup("운동"));
+        Product product = createProduct("제목", "링크", "image1", 50000, "mall", List.of(kg));
+        productRepository.save(product);
+
+        // when
+        List<Product> result = productRepository.findTopByTagsAndPriceRange(List.of("운동"), 30000, 60000);
+
+        // then
+        assertThat(result).hasSize(1).extracting(Product::getTitle).contains("제목");
+    }
+
+    @DisplayName("중복 링크 조회 테스트")
+    @Test
+    void findLinksIn() {
+        // given
+        Product p1 = createProduct("제목1", "링크1", "image1", 50000, "mall", List.of());
+        Product p2 = createProduct("제목", "링크2", "image2", 30000, "mall", List.of());
+        productRepository.saveAll(List.of(p1, p2));
+
+        // when
+        Set<String> result = productRepository.findLinksIn(Set.of("링크1", "링크3"));
+
+        // then
+        assertThat(result).containsOnly("링크1");
+    }
+
+    private Product createProduct(String title, String link, String imageUrl, Integer price,
+                                  String mallName, List<KeywordGroup> keywordGroups) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mallName)
+                .keywordGroups(keywordGroups)
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/RecommendationProductRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/RecommendationProductRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.*;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecommendationProductRepositoryTest {
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private RecommendationProductRepository recommendationProductRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationProductRepository.deleteAllInBatch();
+        recommendationResultRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("추천 결과 ID로 상품 목록을 조회할 수 있다.")
+    @Test
+    void findProductsByResultId() {
+        // given
+
+        Product product = createProduct("제목", "링크", "image", 10000, "mall");
+        productRepository.save(product);
+
+        RecommendationResult result = createRecommendationResult(guest, recommendationSession);
+        recommendationResultRepository.save(result);
+
+        recommendationProductRepository.save(RecommendationProduct.builder()
+                .recommendationResult(result)
+                .product(product)
+                .build());
+
+        // when
+        List<Product> resultList = recommendationProductRepository.findProductsByResultId(result.getId());
+
+        // then
+        assertThat(resultList).hasSize(1).contains(product);
+    }
+
+    private static RecommendationResult createRecommendationResult(Guest guest, RecommendationSession recommendationSession) {
+        return RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .keywords(List.of())
+                .build();
+    }
+
+    private static Product createProduct(String title, String link, String imageUrl, Integer price, String mallName) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mallName)
+                .keywordGroups(List.of())
+                .build();
+    }
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/RecommendationResultRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/RecommendationResultRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.entity.RecommendationResult;
+import com.example.giftrecommender.domain.entity.RecommendationSession;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RecommendationResultRepositoryTest {
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationResultRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("추천 세션 ID로 추천 결과를 조회할 수 있다.")
+    @Test
+    void findByRecommendationSessionId() {
+        // given
+        RecommendationResult recommendationResult = RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .build();
+        recommendationResultRepository.save(recommendationResult);
+
+        // when
+        Optional<RecommendationResult> result =
+                recommendationResultRepository.findByRecommendationSessionId(recommendationSession.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getRecommendationSession().getId()).isEqualTo(recommendationSession.getId());
+    }
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.example.giftrecommender.domain.repository.answer_option;
+
+import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.domain.repository.question.QuestionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AnswerOptionRepositoryTest {
+
+    @Autowired
+    private AnswerOptionRepository answerOptionRepository;
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    private Question question;
+
+    @BeforeEach
+    void setUp() {
+        question = questionRepository.save(
+                Question.builder()
+                        .content("취미는?")
+                        .type(QuestionType.CHOICE)
+                        .order(1)
+                        .build()
+        );
+    }
+
+    @DisplayName("특정 질문 ID에 대한 모든 선택지를 조회할 수 있다")
+    @Test
+    void findAllByQuestionId() {
+        // given
+        AnswerOption a1 = createAnswerOption("운동", "운동", question);
+        AnswerOption a2 = createAnswerOption("독서", "책", question);
+
+        answerOptionRepository.saveAll(List.of(a1, a2));
+
+        // when
+        List<AnswerOption> result = answerOptionRepository.findAllByQuestionId(question.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getQuestion().getId()).isEqualTo(question.getId());
+    }
+
+    private static AnswerOption createAnswerOption(String content, String recommendationKeyword, Question question) {
+        return AnswerOption.builder()
+                .content(content)
+                .recommendationKeyword(recommendationKeyword)
+                .question(question)
+                .build();
+    }
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/keyword/KeywordGroupRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.example.giftrecommender.domain.repository.keyword;
+
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class KeywordGroupRepositoryTest {
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @DisplayName("여러 키워드로 키워드 그룹을 조회할 수 있다.")
+    @Test
+    void findByMainKeywordIn() {
+        // given
+        keywordGroupRepository.save(new KeywordGroup("운동"));
+        keywordGroupRepository.save(new KeywordGroup("건강"));
+
+        // when
+        List<KeywordGroup> results = keywordGroupRepository.findByMainKeywordIn(List.of("운동", "건강", "다이어트"));
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results).extracting(KeywordGroup::getMainKeyword).contains("운동", "건강");
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.example.giftrecommender.domain.repository.question;
+
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class QuestionRepositoryTest {
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @DisplayName("질문을 order 기준으로 오름차순 정렬하여 모두 조회할 수 있다")
+    @Test
+    void findAllByOrderByOrderAsc() {
+        // given
+        Question q1 = createQuestion("질문 1", 2);
+        Question q2 = createQuestion("질문 2", 1);
+        questionRepository.saveAll(List.of(q1, q2));
+
+        // when
+        List<Question> result = questionRepository.findAllByOrderByOrderAsc();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getOrder()).isEqualTo(1);
+        assertThat(result.get(1).getOrder()).isEqualTo(2);
+    }
+
+    private static Question createQuestion(String content, int order) {
+        return Question.builder()
+                .content(content)
+                .type(QuestionType.CHOICE)
+                .order(order)
+                .build();
+    }
+}

--- a/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
+++ b/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
@@ -1,0 +1,108 @@
+package com.example.giftrecommender.infra.naver;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+class NaverApiClientTest {
+    static class TestReflection {
+        public static void setField(Object target, String fieldName, Object value) {
+            try {
+                Field f = target.getClass().getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(target, value);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Mock
+    private RedisQuotaManager quotaManager;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private NaverApiClient naverApiClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        TestReflection.setField(naverApiClient, "clientId", "test-client-id");
+        TestReflection.setField(naverApiClient, "clientSecret", "test-client-secret");
+    }
+
+    @DisplayName("네이버 API에서 정상적으로 상품을 파싱한다.")
+    @Test
+    void testSearch_success() throws Exception {
+        // given
+        when(quotaManager.canCall()).thenReturn(true);
+
+        String json = """
+        {
+          "items": [
+            {
+              "title": "테스트 상품",
+              "link": "http://example.com",
+              "image": "http://example.com/image.jpg",
+              "lprice": "12345",
+              "mallName": "테스트몰"
+            }
+          ]
+        }
+        """;
+
+        JsonNode mockResponse = new ObjectMapper().readTree(json);
+
+        ResponseEntity<JsonNode> responseEntity = new ResponseEntity<>(mockResponse, HttpStatus.OK);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(JsonNode.class)))
+                .thenReturn(responseEntity);
+
+        // when
+        List<ProductResponseDto> result = naverApiClient.search("테스트", 1, 10);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).title()).isEqualTo("테스트 상품");
+        assertThat(result.get(0).lprice()).isEqualTo(12345);
+    }
+
+    @DisplayName("쿼터 초과 시 예외가 발생해야 한다.")
+    @Test
+    void testSearch_quotaExceeded() {
+        // given
+        when(quotaManager.canCall()).thenReturn(false);
+
+        // when then
+        assertThatThrownBy(() -> naverApiClient.search("테스트", 1, 10))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.QUOTA_EXCEEDED.getMessage());
+    }
+}

--- a/src/test/java/com/example/giftrecommender/service/GuestServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/GuestServiceTest.java
@@ -1,0 +1,39 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.repository.GuestRepository;
+import com.example.giftrecommender.dto.response.GuestResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class GuestServiceTest {
+
+    @Autowired private GuestService guestService;
+
+    @Autowired private GuestRepository guestRepository;
+
+    @DisplayName("게스트가 생성되고 저장되어야 한다.")
+    @Test
+    void createAndStoreGuest() {
+        // when
+        GuestResponseDto response = guestService.createGuest();
+
+        // then
+        UUID guestId = response.guestId();
+        Optional<Guest> savedGuest = guestRepository.findById(guestId);
+
+        assertThat(savedGuest).isPresent();
+        assertThat(savedGuest.get().getId()).isEqualTo(guestId);
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.giftrecommender.service;
+
+
+import com.example.giftrecommender.domain.entity.Product;
+import com.example.giftrecommender.domain.repository.ProductRepository;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.dto.response.ProductResponseDto;
+import com.example.giftrecommender.infra.naver.NaverApiClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ProductImportServiceTest {
+
+    @Autowired private ProductImportService productImportService;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @MockBean private NaverApiClient naverApiClient;
+
+    @AfterEach
+    void tearDown() {
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("상품이 조건에 맞게 저장된다")
+    @Test
+    void importUntilEnoughPriceMatches() {
+        // given
+        List<String> tags = List.of("감성", "우아한");
+        String priceKeyword = "5~10만원";
+        String receiver = "연인";
+        String reason = "생일";
+
+        ProductResponseDto mockDto = new ProductResponseDto(
+                UUID.randomUUID(),
+                "우아한 감성 커플 선물",
+                "https://example.com/product1",
+                "https://example.com/image1.jpg",
+                89000,
+                "쿠팡"
+        );
+
+        when(naverApiClient.search(anyString(), eq(1), eq(100)))
+                .thenReturn(List.of(mockDto));
+        when(naverApiClient.search(anyString(), intThat(i -> i > 1), eq(100)))
+                .thenReturn(List.of());
+
+        // when
+        productImportService.importUntilEnough(tags, priceKeyword, receiver, reason, 1);
+
+        // then
+        List<Product> saved = productRepository.findAll();
+        assertThat(saved).hasSize(1);
+        Product savedProduct = saved.get(0);
+        assertThat(savedProduct.getPrice()).isEqualTo(89000);
+        assertThat(savedProduct.getTitle()).contains("감성");
+        assertThat(savedProduct.getLink()).isEqualTo("https://example.com/product1");
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/QuestionServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/QuestionServiceTest.java
@@ -1,0 +1,70 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.domain.repository.answer_option.AnswerOptionRepository;
+import com.example.giftrecommender.domain.repository.question.QuestionRepository;
+import com.example.giftrecommender.dto.response.QuestionResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class QuestionServiceTest {
+
+    @Autowired private QuestionService questionService;
+
+    @Autowired private QuestionRepository questionRepository;
+
+    @Autowired private AnswerOptionRepository answerOptionRepository;
+
+    @DisplayName("질문과 선택지를 순서대로 조회할 수 있다.")
+    @Test
+    void getAllQuestionSuccess() {
+        // given
+        Question q1 = questionRepository.save(createQuestion("Q1 내용", 1));
+        Question q2 = questionRepository.save(createQuestion("Q2 내용", 2));
+
+        answerOptionRepository.save(createAnswerOption("선택지1", "키워드1", q1));
+        answerOptionRepository.save(createAnswerOption("선택지2", "키워드2", q1));
+        answerOptionRepository.save(createAnswerOption("선택지1", "키워드3", q2));
+        answerOptionRepository.save(createAnswerOption("선택지2", "키워드4", q2));
+        answerOptionRepository.save(createAnswerOption("선택지3", "키워드5", q2));
+
+        // when
+        List<QuestionResponseDto> result = questionService.getAllQuestion();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).content()).isEqualTo("Q1 내용");
+        assertThat(result.get(0).options()).hasSize(2);
+        assertThat(result.get(1).content()).isEqualTo("Q2 내용");
+        assertThat(result.get(1).options()).hasSize(3);
+    }
+
+    private AnswerOption createAnswerOption(String content, String recommendationKeyword, Question question) {
+        return AnswerOption.builder()
+                .content(content)
+                .recommendationKeyword(recommendationKeyword)
+                .question(question)
+                .build();
+    }
+
+    private Question createQuestion(String content, Integer order) {
+        return Question.builder()
+                .content(content)
+                .type(QuestionType.CHOICE)
+                .order(order)
+                .build();
+    }
+
+
+}

--- a/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
@@ -1,0 +1,236 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.common.quota.RedisQuotaManager;
+import com.example.giftrecommender.domain.entity.*;
+import com.example.giftrecommender.domain.entity.keyword.KeywordGroup;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import com.example.giftrecommender.domain.repository.*;
+import com.example.giftrecommender.domain.repository.keyword.KeywordGroupRepository;
+import com.example.giftrecommender.dto.response.RecommendationResponseDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class RecommendationServiceTest {
+
+    @Autowired private RecommendationService recommendationService;
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository recommendationSessionRepository;
+
+    @Autowired private ProductRepository productRepository;
+
+    @Autowired private RecommendationResultRepository recommendationResultRepository;
+
+    @Autowired private RecommendationProductRepository recommendationProductRepository;
+
+    @Autowired private KeywordGroupRepository keywordGroupRepository;
+
+    @MockBean private RedisQuotaManager redisQuotaManager;
+
+    @MockBean private ProductImportService productImportService;
+
+    private Guest guest;
+
+    private RecommendationSession recommendationSession;
+
+    private List<Product> products = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        guest = createGuest();
+        guestRepository.save(guest);
+
+        recommendationSession = createRecommendationSession("테스트", guest);
+        recommendationSessionRepository.save(recommendationSession);
+
+        KeywordGroup k1 = new KeywordGroup("연인");
+        KeywordGroup k2 = new KeywordGroup("생일");
+        KeywordGroup k3 = new KeywordGroup("악세서리");
+        KeywordGroup k4 = new KeywordGroup("반지");
+        KeywordGroup k5 = new KeywordGroup("금");
+        keywordGroupRepository.saveAll(List.of(k1, k2, k3, k4, k5));
+
+        for (int i = 1; i <= 4; i++) {
+            products.add(
+                    createProduct(
+                            "악세서리 반지 금 여자친구 생일",
+                            "https://example.com/" + i,
+                            "https://img.com/" + i + ".jpg",
+                            90000,
+                            "브랜드" + i,
+                            List.of(k1, k2, k3, k4, k5))
+            );
+        }
+        productRepository.saveAll(products);
+    }
+
+    @AfterEach
+    void tearDown() {
+        recommendationProductRepository.deleteAllInBatch();
+        recommendationResultRepository.deleteAllInBatch();
+        productRepository.deleteAllInBatch();
+        keywordGroupRepository.deleteAllInBatch();
+        recommendationSessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("조건에 맞는 상품이 있을 경우 추천 결과  4개가 성공적으로 반환된다.")
+    @Test
+    void recommendationResultProductsExist() {
+        // given
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+        when(redisQuotaManager.canCall()).thenReturn(true);
+
+        // when
+        RecommendationResponseDto response =
+                recommendationService.recommend(guest.getId(), recommendationSession.getId(), keywords);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.products()).hasSize(4);
+        assertThat(response.products()).allSatisfy(product ->
+                assertThat(product.title()).contains("반지")
+        );
+    }
+
+    @DisplayName("추천 결과 조회가 정상적으로 동작한다")
+    @Test
+    void getRecommendationResult() {
+        // given
+        RecommendationResult result = recommendationResultRepository.save(RecommendationResult.builder()
+                .guest(guest)
+                .recommendationSession(recommendationSession)
+                .keywords(List.of("악세서리", "반지", "금", "여자친구", "생일"))
+                .build());
+
+        recommendationProductRepository.save(
+                RecommendationProduct.builder()
+                        .recommendationResult(result)
+                        .product(products.get(0))
+                        .build()
+        );
+
+        // when
+        RecommendationResponseDto response =
+                recommendationService.getRecommendationResult(guest.getId(), recommendationSession.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("테스트");
+        assertThat(response.products()).hasSize(1);
+        assertThat(response.products().get(0).title()).contains("반지");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게스트일 경우 예외가 발생한다.")
+    void guestNotFound() {
+        // given
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(UUID.randomUUID(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.GUEST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션일 경우 예외가 발생한다.")
+    void sessionNotFound() {
+        // given
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(guest.getId(), UUID.randomUUID(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.SESSION_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("세션 주인이 아닌 경우 예외가 발생한다.")
+    void sessionOwnerInvalid() {
+        // given
+        Guest anotherGuest = guestRepository.save(createGuest());
+        List<String> keywords = List.of("반지", "5~10만원");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(anotherGuest.getId(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.SESSION_FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("쿼터 초과 시 예외가 발생한다.")
+    void quotaExceeded() {
+        // given
+        when(redisQuotaManager.canCall()).thenReturn(false);
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.recommend(guest.getId(), recommendationSession.getId(), keywords))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.QUOTA_EXCEEDED.getMessage());
+    }
+
+    @Test
+    @DisplayName("추천 결과 조회 시 추천 이력이 없으면 예외가 발생한다.")
+    void recommendationResultNotFound() {
+        // when  then
+        assertThatThrownBy(
+                () -> recommendationService.getRecommendationResult(guest.getId(), recommendationSession.getId()))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.RESULT_NOT_FOUND.getMessage());
+    }
+
+    private static Product createProduct(String title, String link, String imageUrl,
+                                         Integer price, String mall, List<KeywordGroup> keywordGroups) {
+        return Product.builder()
+                .publicId(UUID.randomUUID())
+                .title(title)
+                .link(link)
+                .imageUrl(imageUrl)
+                .price(price)
+                .mallName(mall)
+                .keywordGroups(keywordGroups)
+                .build();
+    }
+
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/RecommendationSessionServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/RecommendationSessionServiceTest.java
@@ -1,0 +1,74 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.repository.GuestRepository;
+import com.example.giftrecommender.domain.repository.RecommendationSessionRepository;
+import com.example.giftrecommender.dto.request.RecommendationSessionRequestDto;
+import com.example.giftrecommender.dto.response.RecommendationSessionResponseDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class RecommendationSessionServiceTest {
+
+    @Autowired private RecommendationSessionService recommendationSessionService;
+    @Autowired private GuestRepository guestRepository;
+    @Autowired private RecommendationSessionRepository sessionRepository;
+
+    private Guest guest;
+
+    @BeforeEach
+    void setUp() {
+        guest = guestRepository.save(Guest.builder().id(UUID.randomUUID()).build());
+    }
+
+    @AfterEach
+    void tearDown() {
+        sessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("게스트 ID로 추천 세션을 생성할 수 있다.")
+    @Test
+    void createRecommendationSessionSuccess() {
+        // given
+        RecommendationSessionRequestDto requestDto = new RecommendationSessionRequestDto("테스트");
+
+        // when
+        RecommendationSessionResponseDto response = recommendationSessionService.createRecommendationSession(guest.getId(), requestDto);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.recommendationSessionId()).isNotNull();
+        assertThat(response.name()).isEqualTo("테스트");
+    }
+
+    @DisplayName("존재하지 않는 게스트 ID로 세션 생성 시 예외가 발생한다")
+    @Test
+    void createRecommendationSession_fail_whenGuestNotFound() {
+        // given
+        UUID invalidGuestId = UUID.randomUUID();
+        RecommendationSessionRequestDto requestDto = new RecommendationSessionRequestDto("테스트");
+
+        // when & then
+        assertThatThrownBy(() ->
+                recommendationSessionService.createRecommendationSession(invalidGuestId, requestDto)
+        )
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.GUEST_NOT_FOUND.getMessage());
+    }
+
+}

--- a/src/test/java/com/example/giftrecommender/service/UserAnswerServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/UserAnswerServiceTest.java
@@ -1,0 +1,216 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.domain.entity.Guest;
+import com.example.giftrecommender.domain.entity.RecommendationSession;
+import com.example.giftrecommender.domain.entity.UserAnswer;
+import com.example.giftrecommender.domain.entity.answer_option.AiAnswerOption;
+import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
+import com.example.giftrecommender.domain.entity.question.AiQuestion;
+import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.QuestionType;
+import com.example.giftrecommender.domain.enums.SessionStatus;
+import com.example.giftrecommender.domain.repository.GuestRepository;
+import com.example.giftrecommender.domain.repository.RecommendationSessionRepository;
+import com.example.giftrecommender.domain.repository.UserAnswerRepository;
+import com.example.giftrecommender.domain.repository.answer_option.AiAnswerOptionRepository;
+import com.example.giftrecommender.domain.repository.answer_option.AnswerOptionRepository;
+import com.example.giftrecommender.domain.repository.question.AiQuestionRepository;
+import com.example.giftrecommender.domain.repository.question.QuestionRepository;
+import com.example.giftrecommender.dto.request.AnswerOptionRequestDto;
+import com.example.giftrecommender.dto.request.QuestionRequestDto;
+import com.example.giftrecommender.dto.request.UserAnswerAiRequestDto;
+import com.example.giftrecommender.dto.request.UserAnswerRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class UserAnswerServiceTest {
+
+    @Autowired private UserAnswerService userAnswerService;
+
+    @Autowired private GuestRepository guestRepository;
+
+    @Autowired private RecommendationSessionRepository sessionRepository;
+
+    @Autowired private QuestionRepository questionRepository;
+
+    @Autowired private AnswerOptionRepository answerOptionRepository;
+
+    @Autowired private AiQuestionRepository aiQuestionRepository;
+
+    @Autowired private AiAnswerOptionRepository aiAnswerOptionRepository;
+
+    @Autowired private UserAnswerRepository userAnswerRepository;
+
+    private Guest guest;
+
+    private RecommendationSession session;
+
+    private List<Question> questions = new ArrayList<>();
+    private List<AnswerOption> answerOptions = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        guest = guestRepository.save(createGuest());
+        session = sessionRepository.save(
+                createRecommendationSession("테스트", guest));
+
+        Question q1 = questionRepository.save(createQuestion("Q1 내용", 1));
+        Question q2 = questionRepository.save(createQuestion("Q2 내용", 2));
+        questions.addAll(List.of(q1,q2));
+        questionRepository.saveAll(questions);
+
+        AnswerOption a1 = answerOptionRepository.save(createAnswerOption("선택지1", "키워드1", q1));
+        AnswerOption a2 = answerOptionRepository.save(createAnswerOption("선택지2", "키워드2", q1));
+        AnswerOption a3 = answerOptionRepository.save(createAnswerOption("선택지1", "키워드3", q2));
+        AnswerOption a4 = answerOptionRepository.save(createAnswerOption("선택지2", "키워드4", q2));
+        AnswerOption a5 = answerOptionRepository.save(createAnswerOption("선택지3", "키워드5", q2));
+        answerOptions.addAll(List.of(a1, a2, a3, a4, a5));
+        answerOptionRepository.saveAll(answerOptions);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userAnswerRepository.deleteAllInBatch();
+        aiAnswerOptionRepository.deleteAllInBatch();
+        aiQuestionRepository.deleteAllInBatch();
+        answerOptionRepository.deleteAllInBatch();
+        questionRepository.deleteAllInBatch();
+        sessionRepository.deleteAllInBatch();
+        guestRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("고정형 답변을 저장할 수 있다.")
+    @Test
+    void saveUserAnswer() {
+        // given
+        Question question = questions.get(0);
+        AnswerOption option = answerOptions.get(0);
+        UserAnswerRequestDto request = new UserAnswerRequestDto(question.getId(), QuestionType.CHOICE, option.getId());
+
+        // when
+        userAnswerService.saveAnswer(guest.getId(), session.getId(), request);
+
+        // then
+        List<UserAnswer> saved = userAnswerRepository.findAll();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getGuest().getId()).isEqualTo(guest.getId());
+    }
+
+    @DisplayName("AI 질문, 선택지와 답변을 저장할 수 있다.")
+    @Test
+    @Transactional
+    void saveAiUserAnswer() {
+        // given
+        QuestionRequestDto requestDto = new QuestionRequestDto("AI 질문 내용", QuestionType.CHOICE, 4);
+        AnswerOptionRequestDto option1 = new AnswerOptionRequestDto("1번 보기", "키워드1");
+        AnswerOptionRequestDto option2 = new AnswerOptionRequestDto("2번 보기", "키워드2");
+        UserAnswerAiRequestDto userAnswerAiRequestDto = new UserAnswerAiRequestDto(requestDto, List.of(option1, option2), 1);
+
+        // when
+        userAnswerService.saveAiQuestionAndAnswer(guest.getId(), session.getId(), userAnswerAiRequestDto);
+
+        // then
+        List<AiQuestion> savedQuestions = aiQuestionRepository.findAll();
+        List<AiAnswerOption> savedOptions = aiAnswerOptionRepository.findAll();
+        List<UserAnswer> savedAnswers = userAnswerRepository.findAll();
+
+        assertThat(savedQuestions).hasSize(1);
+        assertThat(savedOptions).hasSize(2);
+        assertThat(savedAnswers).hasSize(1);
+        assertThat(savedAnswers.get(0).getAiAnswerOption().getContent()).isEqualTo("2번 보기");
+    }
+
+    @DisplayName("게스트가 존재하지 않으면 예외가 발생한다")
+    @Test
+    void userAnswerGuestNotFound() {
+        // given
+        UUID invalidGuestId = UUID.randomUUID();
+        Question question = questions.get(0);
+        AnswerOption option = answerOptions.get(0);
+        UserAnswerRequestDto request = new UserAnswerRequestDto(question.getId(), QuestionType.CHOICE, option.getId());
+
+        // when & then
+        assertThatThrownBy(() -> userAnswerService.saveAnswer(invalidGuestId, session.getId(), request))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.GUEST_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("세션이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void userAnswerSessionNotFound() {
+        // given
+        UUID invalidSessionId = UUID.randomUUID();
+        Question question = questions.get(0);
+        AnswerOption option = answerOptions.get(0);
+        UserAnswerRequestDto request = new UserAnswerRequestDto(question.getId(), QuestionType.CHOICE, option.getId());
+
+        // when & then
+        assertThatThrownBy(() -> userAnswerService.saveAnswer(guest.getId(), invalidSessionId, request))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.SESSION_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("세션이 해당 게스트의 세션이 아니면 예외가 발생한다.")
+    @Test
+    void userAnswerSessionNotOwnedByGuest() {
+        // given
+        Guest otherGuest = guestRepository.save(createGuest());
+        Question question = questions.get(0);
+        AnswerOption option = answerOptions.get(0);
+        UserAnswerRequestDto request = new UserAnswerRequestDto(question.getId(), QuestionType.CHOICE, option.getId());
+
+        // when & then
+        assertThatThrownBy(() -> userAnswerService.saveAnswer(otherGuest.getId(), session.getId(), request))
+                .isInstanceOf(ErrorException.class)
+                .hasMessageContaining(ExceptionEnum.FORBIDDEN.getMessage());
+    }
+
+    private AnswerOption createAnswerOption(String content, String recommendationKeyword, Question question) {
+        return AnswerOption.builder()
+                .content(content)
+                .recommendationKeyword(recommendationKeyword)
+                .question(question)
+                .build();
+    }
+
+    private Question createQuestion(String content, Integer order) {
+        return Question.builder()
+                .content(content)
+                .type(QuestionType.CHOICE)
+                .order(order)
+                .build();
+    }
+
+    private static RecommendationSession createRecommendationSession(String name, Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .name(name)
+                .status(SessionStatus.PENDING)
+                .guest(guest)
+                .build();
+    }
+
+    private static Guest createGuest() {
+        return Guest.builder()
+                .id(UUID.randomUUID())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 주요 변경 사항

### 1. 추천 도메인 리팩토링
- `RecommendationProduct`에 `@Builder` 적용
- 관련 생성 로직을 Builder 패턴으로 리팩토링

### 2. NaverApiClient 테스트 개선
- `NaverApiClientTest` 추가
- `RestTemplate`, `RedisQuotaManager`를 `@Mock` 처리하여 외부 의존성 제거
- `@Value` 필드 주입은 `TestReflection` 유틸로 설정
- `RestTemplate` 직접 생성 방식 제거 → Spring Bean 주입 방식으로 개선

### 3. Repository 단위 테스트 추가
- `QuestionRepositoryTest`: `findAllByOrderByOrderAsc()` 정렬 테스트
- `AnswerOptionRepositoryTest`: 질문 ID 기반 선택지 조회 테스트
- `ProductRepositoryTest`: 키워드 + 가격 필터 기반 상품 조회
- `RecommendationResultRepositoryTest`: 세션 ID 기반 추천 결과 조회
- `RecommendationProductRepositoryTest`: 추천 결과 ID 기반 상품 조회
- `KeywordGroupRepositoryTest`: 키워드 목록 기반 그룹 조회
- 테스트 방식: `@DataJpaTest + @AutoConfigureTestDatabase(replace = NONE)` 활용하여 실제 MySQL 환경에서 테스트

### 4. 추천 API 흐름 테스트
- 추천 API Service 및 WebMvc 테스트 추가
  - 키워드/가격 조건 만족 여부 검증
  - 상품 수 부족 시 Fallback 없이 중단되는 로직 확인
- `importUntilEnough()` 테스트: 조건 만족 시 상품 저장 흐름 확인

### 5. Guest / Session 테스트
- `GuestServiceTest`, `GuestControllerTest`: 비회원 생성 및 저장 흐름 검증
- `RecommendationSessionServiceTest`, `RecommendationSessionControllerTest`: 추천 세션 생성 성공 및 예외 케이스 테스트

### 6. 유저 응답 저장 테스트
- `UserAnswerServiceTest`
  - 고정형 질문 응답 저장 테스트
  - GPT 기반 응답 저장 테스트
  - 게스트/세션 누락 시 예외 테스트
- `UserAnswerControllerTest`, `UserAnswerAiControllerTest`: 각 응답 저장 API에 대한 WebMvc 테스트

### 7. CI/CD 파이프라인 개선
- `-x test` 옵션 제거 -> GitHub Actions에서 전체 테스트 포함 빌드 수행
- 테스트 통과 시에만 배포되도록 구성 -> 운영 안정성 강화

### 8. 기타 설정 및 정리
- CORS 허용 도메인에 프론트엔드 주소(`vercel.app`) 추가
- 사용되지 않는 `RedisQuotaManager#getCallCount` 메서드 제거

## 목적 및 기대 효과
- **추천 API의 전체 흐름에 대한 테스트 확보**로 신뢰성 향상
- **외부 의존성 제거 및 모킹 처리**를 통한 빠르고 안정적인 테스트 실행
- **실제 DB 환경에서의 Repository 동작 확인**
- **불필요한 코드 정리 및 설정 정비**로 유지보수성과 배포 신뢰도 향상