### PR TITLE
feat(recommendation): 추천 결과가 없을 때 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -15,7 +15,8 @@ public enum ExceptionEnum {
     NO_PRODUCT_MATCH(HttpStatus.BAD_REQUEST.value(), "추천 조건에 맞는 상품이 없습니다."),
     QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다."),
     RESULT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "추천 결과를 찾을 수 없습니다."),
-    SESSION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "세션 접근 권한이 없습니다.");
+    SESSION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "세션 접근 권한이 없습니다."),
+    RECOMMENDATION_EMPTY(HttpStatus.BAD_REQUEST.value(), "추천 결과가 없습니다. 키워드를 조정하거나 다시 시도해주세요.");
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/service/RecommendationService.java
+++ b/src/main/java/com/example/giftrecommender/service/RecommendationService.java
@@ -82,6 +82,10 @@ public class RecommendationService {
                 log.info("{} | {}원 | 태그={}", p.getTitle(), p.getPrice(),
                         p.getKeywordGroups().stream().map(KeywordGroup::getMainKeyword).toList()));
 
+        if (finalProducts.isEmpty()) {
+            throw new ErrorException(ExceptionEnum.RECOMMENDATION_EMPTY);
+        }
+
         // 6. 결과 저장
         RecommendationResult result = resultRepository.save(RecommendationResult.builder()
                 .guest(guest)


### PR DESCRIPTION
## 변경 사항
- 추천 로직에서 추천 결과가 비어 있을 경우 `RECOMMENDATION_EMPTY` 예외 발생하도록 처리
- `ExceptionEnum`에 해당 코드 및 메시지 추가

## 추가 설명
- 빈 결과가 무한 로딩으로 이어지던 문제를 해결하기 위한 처리입니다.