### PR TITLE
refactor: 추천 조건 강화 및 중복/유사 상품 필터링 향상

### DIFF
--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -21,7 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://mumusgiftbox.o-r.kr", "https://moomus-gift.vercel.app")
+                .allowedOrigins("https://mumusgiftbox.o-r.kr", "https://moomus-gift.vercel.app", "https://moomu-preview.vercel.app")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/example/giftrecommender/domain/entity/Product.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/Product.java
@@ -40,6 +40,12 @@ public class Product {
     @Column(nullable = false, length = 100)
     private String mallName;
 
+    @Column(length = 100)
+    private String brand;
+
+    @Column(length = 100)
+    private String category3;
+
     // 저장 시점 (TTL 관리 목적)
     private Instant cachedAt;
 
@@ -53,7 +59,8 @@ public class Product {
 
     @Builder
     public Product(UUID publicId, String title, String link, String imageUrl,
-                   Integer price, String mallName, List<KeywordGroup> keywordGroups) {
+                   Integer price, String mallName, List<KeywordGroup> keywordGroups,
+                   String brand, String category3) {
         this.publicId = publicId;
         this.title = title;
         this.link = link;
@@ -61,6 +68,8 @@ public class Product {
         this.price = price;
         this.mallName = mallName;
         this.keywordGroups = keywordGroups;
+        this.brand = brand;
+        this.category3 = category3;
     }
 
     public static Product from(ProductResponseDto dto, List<KeywordGroup> keywordGroups) {
@@ -71,6 +80,8 @@ public class Product {
                 .price(dto.lprice())
                 .mallName(dto.mallName())
                 .keywordGroups(keywordGroups)
+                .brand(dto.brand())
+                .category3(dto.category3())
                 .build();
     }
 

--- a/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/ProductRepository.java
@@ -11,11 +11,18 @@ import java.util.Set;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    @Query("SELECT p FROM Product p JOIN p.keywordGroups kg WHERE kg.mainKeyword IN :keywords AND p.price BETWEEN :min AND :max")
+    @Query("""
+                SELECT p FROM Product p
+                JOIN p.keywordGroups kg
+                WHERE kg.mainKeyword IN :keywords
+                  AND p.price BETWEEN :minPrice AND :maxPrice
+                GROUP BY p
+                HAVING COUNT(DISTINCT kg.mainKeyword) >= 3
+            """)
     List<Product> findTopByTagsAndPriceRange(
             @Param("keywords") List<String> keywords,
-            @Param("min") int min,
-            @Param("max") int max
+            @Param("minPrice") int minPrice,
+            @Param("maxPrice") int maxPrice
     );
 
     @Query("SELECT p.link FROM Product p WHERE p.link IN :links")

--- a/src/main/java/com/example/giftrecommender/dto/response/ProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/ProductResponseDto.java
@@ -8,5 +8,7 @@ public record ProductResponseDto(
         String link,
         String image,
         int lprice,
-        String mallName
+        String mallName,
+        String brand,
+        String category3
 ) {}

--- a/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
+++ b/src/main/java/com/example/giftrecommender/infra/naver/NaverApiClient.java
@@ -77,7 +77,9 @@ public class NaverApiClient {
                     item.get("link").asText(),
                     item.get("image").asText(),
                     item.get("lprice").asInt(),
-                    item.get("mallName").asText()
+                    item.get("mallName").asText(),
+                    item.has("brand") ? item.get("brand").asText() : null,
+                    item.has("category3") ? item.get("category3").asText() : null
             ));
         }
 

--- a/src/test/java/com/example/giftrecommender/domain/entity/ProductTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/entity/ProductTest.java
@@ -18,7 +18,8 @@ class ProductTest {
     @Test
     void testFromDto() {
         // given
-        ProductResponseDto dto = new ProductResponseDto(UUID.randomUUID(), "title <b>bold</b>", "link", "image", 10000, "mall");
+        ProductResponseDto dto = new ProductResponseDto(UUID.randomUUID(), "title <b>bold</b>", "link",
+                "image", 10000, "mall", "브랜드", "카테고리");
         List<KeywordGroup> keywords = List.of(new KeywordGroup("여자친구"));
 
         // when

--- a/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/ProductRepositoryTest.java
@@ -36,12 +36,14 @@ class ProductRepositoryTest {
     @Test
     void findTopByTagsAndPriceRange() {
         // given
-        KeywordGroup kg = keywordGroupRepository.save(new KeywordGroup("운동"));
-        Product product = createProduct("제목", "링크", "image1", 50000, "mall", List.of(kg));
+        KeywordGroup kg1 = keywordGroupRepository.save(new KeywordGroup("운동"));
+        KeywordGroup kg2 = keywordGroupRepository.save(new KeywordGroup("러닝화"));
+        KeywordGroup kg3 = keywordGroupRepository.save(new KeywordGroup("러닝가방"));
+        Product product = createProduct("제목", "링크", "image1", 50000, "mall", List.of(kg1, kg2, kg3));
         productRepository.save(product);
 
         // when
-        List<Product> result = productRepository.findTopByTagsAndPriceRange(List.of("운동"), 30000, 60000);
+        List<Product> result = productRepository.findTopByTagsAndPriceRange(List.of("운동", "러닝화", "러닝가방"), 30000, 60000);
 
         // then
         assertThat(result).hasSize(1).extracting(Product::getTitle).contains("제목");

--- a/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
+++ b/src/test/java/com/example/giftrecommender/infra/naver/NaverApiClientTest.java
@@ -73,7 +73,9 @@ class NaverApiClientTest {
               "link": "http://example.com",
               "image": "http://example.com/image.jpg",
               "lprice": "12345",
-              "mallName": "테스트몰"
+              "mallName": "테스트몰",
+              "brand": "브랜드",
+              "category3": "카테고리"
             }
           ]
         }

--- a/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/ProductImportServiceTest.java
@@ -54,7 +54,9 @@ class ProductImportServiceTest {
                 "https://example.com/product1",
                 "https://example.com/image1.jpg",
                 89000,
-                "쿠팡"
+                "쿠팡",
+                "브랜드",
+                "카테고리"
         );
 
         when(naverApiClient.search(anyString(), eq(1), eq(100)))

--- a/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
@@ -62,7 +62,7 @@ class RecommendationServiceTest {
         recommendationSession = createRecommendationSession("테스트", guest);
         recommendationSessionRepository.save(recommendationSession);
 
-        KeywordGroup k1 = new KeywordGroup("연인");
+        KeywordGroup k1 = new KeywordGroup("여자친구");
         KeywordGroup k2 = new KeywordGroup("생일");
         KeywordGroup k3 = new KeywordGroup("악세서리");
         KeywordGroup k4 = new KeywordGroup("반지");
@@ -70,15 +70,15 @@ class RecommendationServiceTest {
         keywordGroupRepository.saveAll(List.of(k1, k2, k3, k4, k5));
 
         for (int i = 1; i <= 4; i++) {
-            products.add(
-                    createProduct(
-                            "악세서리 반지 금 여자친구 생일",
-                            "https://example.com/" + i,
-                            "https://img.com/" + i + ".jpg",
-                            90000,
-                            "브랜드" + i,
-                            List.of(k1, k2, k3, k4, k5))
-            );
+            String title = switch (i) {
+                case 1 -> "여자친구 생일 선물 금 반지";
+                case 2 -> "생일 반지 추천 여자친구용";
+                case 3 -> "고급 금 반지 악세서리 선물";
+                case 4 -> "여친 기념일 금 반지 악세서리";
+                default -> "기본 반지";
+            };
+            products.add(createProduct(title, "https://example.com/" + i,
+                    "https://img.com/" + i + ".jpg", 90000, "브랜드" + i, List.of(k1, k2, k3, k4, k5)));
         }
         productRepository.saveAll(products);
     }
@@ -184,6 +184,7 @@ class RecommendationServiceTest {
     @DisplayName("쿼터 초과 시 예외가 발생한다.")
     void quotaExceeded() {
         // given
+        productRepository.deleteAll();
         when(redisQuotaManager.canCall()).thenReturn(false);
         List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
 

--- a/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/RecommendationServiceTest.java
@@ -62,24 +62,38 @@ class RecommendationServiceTest {
         recommendationSession = createRecommendationSession("테스트", guest);
         recommendationSessionRepository.save(recommendationSession);
 
-        KeywordGroup k1 = new KeywordGroup("여자친구");
-        KeywordGroup k2 = new KeywordGroup("생일");
-        KeywordGroup k3 = new KeywordGroup("악세서리");
-        KeywordGroup k4 = new KeywordGroup("반지");
-        KeywordGroup k5 = new KeywordGroup("금");
-        keywordGroupRepository.saveAll(List.of(k1, k2, k3, k4, k5));
+        // 키워드 저장
+        KeywordGroup girlfriend = keywordGroupRepository.save(new KeywordGroup("여자친구"));
+        KeywordGroup birthday = keywordGroupRepository.save(new KeywordGroup("생일"));
+        KeywordGroup moodlight = keywordGroupRepository.save(new KeywordGroup("무드등"));
+        KeywordGroup ring = keywordGroupRepository.save(new KeywordGroup("반지"));
+        KeywordGroup gold = keywordGroupRepository.save(new KeywordGroup("금"));
 
-        for (int i = 1; i <= 4; i++) {
-            String title = switch (i) {
-                case 1 -> "여자친구 생일 선물 금 반지";
-                case 2 -> "생일 반지 추천 여자친구용";
-                case 3 -> "고급 금 반지 악세서리 선물";
-                case 4 -> "여친 기념일 금 반지 악세서리";
-                default -> "기본 반지";
-            };
-            products.add(createProduct(title, "https://example.com/" + i,
-                    "https://img.com/" + i + ".jpg", 90000, "브랜드" + i, List.of(k1, k2, k3, k4, k5)));
-        }
+        // 조합1: ["여자친구","무드등","생일"]
+        products.add(createProduct("스텔라 라이트 오브제", "https://ex.com/1", "https://img.com/1.jpg", 95000, "빛의정원", "라이트하우스", List.of(girlfriend, moodlight, birthday)));
+        products.add(createProduct("드림캐처 별빛 조명", "https://ex.com/2", "https://img.com/2.jpg", 93000, "힐링하우스", "별조명코리아", List.of(girlfriend, moodlight, birthday)));
+        products.add(createProduct("밤하늘 테이블 램프", "https://ex.com/3", "https://img.com/3.jpg", 97000, "조명마을", "무드펄", List.of(girlfriend, moodlight, birthday)));
+
+        // 조합2: ["여자친구","반지","생일"]
+        products.add(createProduct("러브메탈 핑크링", "https://ex.com/4", "https://img.com/4.jpg", 94000, "러브링스몰", "러브링스", List.of(girlfriend, ring, birthday)));
+        products.add(createProduct("메르시 볼드링", "https://ex.com/5", "https://img.com/5.jpg", 95000, "모던쥬얼", "메르시", List.of(girlfriend, ring, birthday)));
+        products.add(createProduct("심장박동 골드링", "https://ex.com/6", "https://img.com/6.jpg", 96000, "하트골드샵", "골드하트", List.of(girlfriend, ring, birthday)));
+
+        // 조합3: ["여자친구","금","생일"]
+        products.add(createProduct("클래식 진주 드롭귀걸이", "https://ex.com/7", "https://img.com/7.jpg", 96000, "로즈앤골드", "클래식뷰", List.of(girlfriend, gold, birthday)));
+        products.add(createProduct("헬렌 체인 뱅글", "https://ex.com/8", "https://img.com/8.jpg", 98000, "골드하임", "헬렌주얼리", List.of(girlfriend, gold, birthday)));
+        products.add(createProduct("루체아 로즈 팬던트", "https://ex.com/9", "https://img.com/9.jpg", 97000, "핑크주얼", "루체아", List.of(girlfriend, gold, birthday)));
+
+        // 조합4: ["여자친구","무드등","반지","생일"]
+        products.add(createProduct("피오레 파스텔 세트", "https://ex.com/10", "https://img.com/10.jpg", 95000, "조이쥬얼", "피오레라", List.of(girlfriend, moodlight, ring, birthday)));
+        products.add(createProduct("미드나잇 앤써 링박스", "https://ex.com/11", "https://img.com/11.jpg", 94000, "빛앤링", "앤써링", List.of(girlfriend, moodlight, ring, birthday)));
+        products.add(createProduct("글로우 뷰티 조명키트", "https://ex.com/12", "https://img.com/12.jpg", 96000, "예쁜반지샵", "글로우존", List.of(girlfriend, moodlight, ring, birthday)));
+
+        // 조합5: ["여자친구","무드등","금","생일"]
+        products.add(createProduct("라파엘로 캔들보틀", "https://ex.com/13", "https://img.com/13.jpg", 97000, "골드앤라이트", "라파엘로", List.of(girlfriend, moodlight, gold, birthday)));
+        products.add(createProduct("루미에르 스톤 목걸이", "https://ex.com/14", "https://img.com/14.jpg", 99000, "다이아주얼", "루미에르", List.of(girlfriend, moodlight, gold, birthday)));
+        products.add(createProduct("플레르 노블 링세트", "https://ex.com/15", "https://img.com/15.jpg", 96000, "럭스골드", "플레르", List.of(girlfriend, moodlight, gold, birthday)));
+
         productRepository.saveAll(products);
     }
 
@@ -93,11 +107,11 @@ class RecommendationServiceTest {
         guestRepository.deleteAllInBatch();
     }
 
-    @DisplayName("조건에 맞는 상품이 있을 경우 추천 결과  4개가 성공적으로 반환된다.")
+    @DisplayName("조건에 맞는 상품이 있을 경우 추천 결과  10개가 성공적으로 반환된다.")
     @Test
     void recommendationResultProductsExist() {
         // given
-        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "무드등", "반지", "금");
         when(redisQuotaManager.canCall()).thenReturn(true);
 
         // when
@@ -106,10 +120,7 @@ class RecommendationServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.products()).hasSize(4);
-        assertThat(response.products()).allSatisfy(product ->
-                assertThat(product.title()).contains("반지")
-        );
+        assertThat(response.products()).hasSize(10);
     }
 
     @DisplayName("추천 결과 조회가 정상적으로 동작한다")
@@ -119,7 +130,7 @@ class RecommendationServiceTest {
         RecommendationResult result = recommendationResultRepository.save(RecommendationResult.builder()
                 .guest(guest)
                 .recommendationSession(recommendationSession)
-                .keywords(List.of("악세서리", "반지", "금", "여자친구", "생일"))
+                .keywords(List.of("여자친구", "무드등", "반지", "금", "생일"))
                 .build());
 
         recommendationProductRepository.save(
@@ -137,7 +148,7 @@ class RecommendationServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("테스트");
         assertThat(response.products()).hasSize(1);
-        assertThat(response.products().get(0).title()).contains("반지");
+        assertThat(response.products().get(0).title()).contains("오브제");
     }
 
     @Test
@@ -186,7 +197,7 @@ class RecommendationServiceTest {
         // given
         productRepository.deleteAll();
         when(redisQuotaManager.canCall()).thenReturn(false);
-        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "악세서리", "반지", "금");
+        List<String> keywords = List.of("여자친구", "5~10만원", "생일", "무드등", "반지", "금");
 
         // when  then
         assertThatThrownBy(
@@ -206,7 +217,8 @@ class RecommendationServiceTest {
     }
 
     private static Product createProduct(String title, String link, String imageUrl,
-                                         Integer price, String mall, List<KeywordGroup> keywordGroups) {
+                                         Integer price, String mall, String brand,
+                                         List<KeywordGroup> keywordGroups) {
         return Product.builder()
                 .publicId(UUID.randomUUID())
                 .title(title)
@@ -214,9 +226,11 @@ class RecommendationServiceTest {
                 .imageUrl(imageUrl)
                 .price(price)
                 .mallName(mall)
+                .brand(brand)
                 .keywordGroups(keywordGroups)
                 .build();
     }
+
 
 
     private static RecommendationSession createRecommendationSession(String name, Guest guest) {


### PR DESCRIPTION
### 주요 변경사항
- 추천 품질 개선
  - 추천 키워드 3개 이상 매칭되는 상품만 대상으로 필터링 강화
  - 추천 결과 개수 기준을 최소 10개 확보로 상향 조정
  - 추천 결과가 없을 경우 예외 발생하도록 처리

- 상품 중복 제거 로직 개선
  - 상품 제목 정규화 및 자카드 유사도 기반 중복 제거 추가
  - 콤보당 최대 2개만 저장하도록 제한하여 동일 카테고리 쏠림 방지
  - 브랜드 중복 방지 및 유아/아동 상품 자동 제외 로직 추가

- 유틸 및 테스트 추가
  - 키워드 조합 생성 방식 개선
  - 다양한 제목 유사도 테스트 및 추천 조건 테스트 보강
  - 네이버 상품 응답에 브랜드/카테고리 필드 추가 및 파싱
  - CORS 설정에 preview 도메인 추가

- 기대 효과
  - 추천 결과 다양성 확보 및 사용자 경험 개선
  - 유사하거나 부적절한 상품 제거를 통한 정확한 추천 제공
  - API 응답 및 테스트 신뢰도 향상