### PR TITLE
feat(user-answer): TEXT 응답 저장 기능 및 관련 구조 리팩토링

### DIFF
--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -17,7 +17,8 @@ public enum ExceptionEnum {
     SESSION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "세션 접근 권한이 없습니다."),
     RECOMMENDATION_EMPTY(HttpStatus.BAD_REQUEST.value(), "추천 결과가 없습니다. 키워드를 조정하거나 다시 시도해주세요."),
     QUOTA_SECOND_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "잠시 후 다시 시도해주세요. (초당 호출 제한)"),
-    QUOTA_DAILY_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다.");
+    QUOTA_DAILY_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 파라미터가 올바르지 않습니다.");
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/domain/entity/UserAnswer.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/UserAnswer.java
@@ -4,6 +4,7 @@ import com.example.giftrecommender.domain.entity.answer_option.AiAnswerOption;
 import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
 import com.example.giftrecommender.domain.entity.question.AiQuestion;
 import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.AnswerOptionType;
 import com.example.giftrecommender.domain.enums.QuestionType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -48,40 +49,53 @@ public class UserAnswer {
     private AiAnswerOption aiAnswerOption;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private QuestionType type;
+    @Column(name = "question_type", nullable = false, length = 20)
+    private QuestionType questionType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_option_type", nullable = false, length = 20)
+    private AnswerOptionType answerOptionType;
+
+    @Column(name = "answer_text", length = 300)
+    private String answerText;
 
     private Instant createdAt;
 
     // 고정 질문 생성자
-    public UserAnswer(Guest guest, RecommendationSession recommendationSession,
-                      Question question, AnswerOption answerOption, QuestionType type) {
+    public UserAnswer(Guest guest, RecommendationSession recommendationSession, Question question, AnswerOption answerOption,
+                      QuestionType questionType, AnswerOptionType answerOptionType, String answerText) {
         this.guest = guest;
         this.recommendationSession = recommendationSession;
         this.question = question;
         this.answerOption = answerOption;
-        this.type = type;
+        this.questionType = questionType;
+        this.answerOptionType = answerOptionType;
+        this.answerText = answerText;
     }
 
     public static UserAnswer ofFixed(Guest guest, RecommendationSession recommendationSession,
-                                     Question question, AnswerOption answerOption, QuestionType type) {
-        return new UserAnswer(guest, recommendationSession, question, answerOption, type);
+                                     Question question, AnswerOption answerOption,
+                                     QuestionType questionType, AnswerOptionType answerOptionType, String answerText) {
+        return new UserAnswer(guest, recommendationSession, question, answerOption, questionType, answerOptionType, answerText);
     }
 
     // GPT 질문 생성자
-    public UserAnswer(Guest guest, RecommendationSession recommendationSession,
-                      AiQuestion aiQuestion, AiAnswerOption aiAnswerOption, QuestionType type) {
+    public UserAnswer(Guest guest, RecommendationSession recommendationSession, AiQuestion aiQuestion, AiAnswerOption aiAnswerOption,
+                      QuestionType questionType, AnswerOptionType answerOptionType, String answerText) {
         this.guest = guest;
         this.recommendationSession = recommendationSession;
         this.aiQuestion = aiQuestion;
         this.aiAnswerOption = aiAnswerOption;
-        this.type = type;
+        this.questionType = questionType;
+        this.answerOptionType = answerOptionType;
+        this.answerText = answerText;
     }
 
 
     public static UserAnswer ofAi(Guest guest, RecommendationSession recommendationSession,
-                      AiQuestion aiQuestion, AiAnswerOption aiAnswerOption, QuestionType type) {
-        return new UserAnswer(guest, recommendationSession, aiQuestion, aiAnswerOption, type);
+                                  AiQuestion aiQuestion, AiAnswerOption aiAnswerOption,
+                                  QuestionType questionType, AnswerOptionType answerOptionType, String answerText) {
+        return new UserAnswer(guest, recommendationSession, aiQuestion, aiAnswerOption, questionType, answerOptionType, answerText);
     }
 
     @PrePersist

--- a/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AiAnswerOption.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/answer_option/AiAnswerOption.java
@@ -24,8 +24,8 @@ public class AiAnswerOption {
     private String content;
 
     // 프론트에서 선택한 선택지
-    @Column(nullable = false)
-    private int selectedIndex;
+    @Column
+    private Integer selectedIndex;
 
     @Builder
     public AiAnswerOption(AiQuestion question, String content, int selectedIndex) {

--- a/src/main/java/com/example/giftrecommender/domain/enums/AnswerOptionType.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/AnswerOptionType.java
@@ -1,0 +1,6 @@
+package com.example.giftrecommender.domain.enums;
+
+public enum AnswerOptionType {
+    CHOICE, TEXT
+}
+

--- a/src/main/java/com/example/giftrecommender/domain/enums/QuestionType.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/QuestionType.java
@@ -1,5 +1,5 @@
 package com.example.giftrecommender.domain.enums;
 
 public enum QuestionType {
-    CHOICE, TEXT
+    FIXED, AI
 }

--- a/src/main/java/com/example/giftrecommender/dto/request/UserAnswerAiRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/UserAnswerAiRequestDto.java
@@ -1,14 +1,16 @@
 package com.example.giftrecommender.dto.request;
 
+import com.example.giftrecommender.domain.enums.AnswerOptionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
+
 
 @Schema(description = "GPT 기반 질문과 선택지에 대한 유저 응답을 담는 요청 DTO (질문, 선택지 포함)", example = """
 {
   "question": {
     "content": "OO이는 어떤 느낌의 선물을 좋아해?",
-    "type": "CHOICE",
+    "type": "AI",
     "order": 7
   },
   "options": [
@@ -22,7 +24,9 @@ import java.util.List;
       "content": "가성비"
     }
   ],
-  "selectedIndex": 1
+  "selectedIndex": 1,
+  "answerText": "트렌디",
+  "answerOptionType": "CHOICE"
 }
 """)
 public record UserAnswerAiRequestDto(
@@ -34,6 +38,12 @@ public record UserAnswerAiRequestDto(
         List<AnswerOptionRequestDto> options,
 
         @Schema(description = "사용자가 선택한 선택지의 인덱스", example = "1", required = true)
-        int selectedIndex
+        Integer selectedIndex,
+
+        @Schema(description = "직접 입력한 텍스트 (직접 입력일 경우 필수)", example = "보드게임")
+        String answerText,
+
+        @Schema(description = "응답 방식 (CHOICE 또는 TEXT)", example = "CHOICE", required = true)
+        AnswerOptionType answerOptionType
 
 ) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/UserAnswerRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/UserAnswerRequestDto.java
@@ -1,15 +1,22 @@
 package com.example.giftrecommender.dto.request;
 
+import com.example.giftrecommender.domain.enums.AnswerOptionType;
 import com.example.giftrecommender.domain.enums.QuestionType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UserAnswerRequestDto (
+public record UserAnswerRequestDto(
         @Schema(description = "질문 ID", example = "1")
         Long questionId,
 
-        @Schema(description = "질문 타입 (CHOICE)", example = "CHOICE")
-        QuestionType type,
+        @Schema(description = "질문 출처 유형 (FIXED)", example = "FIXED")
+        QuestionType questionType,
 
-        @Schema(description = "선택한 답변 옵션 ID", example = "1")
-        Long answerOptionId
+        @Schema(description = "답변 방식 (CHOICE 또는 TEXT)", example = "CHOICE")
+        AnswerOptionType answerOptionType,
+
+        @Schema(description = "선택한 답변 옵션 ID (선택형일 경우 필수)", example = "1")
+        Long answerOptionId,
+
+        @Schema(description = "직접 입력한 텍스트 (TEXT 또는 기타일 경우)", example = "보드게임")
+        String answerText
 ) {}

--- a/src/test/java/com/example/giftrecommender/controller/QuestionControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/QuestionControllerTest.java
@@ -43,7 +43,7 @@ class QuestionControllerTest {
                 new QuestionResponseDto(
                         1L,
                         "누구에게 선물하나요?",
-                        QuestionType.CHOICE,
+                        QuestionType.FIXED,
                         1,
                         optionList
                 )
@@ -57,7 +57,7 @@ class QuestionControllerTest {
                 .andExpect(jsonPath("$.message").value("질문 목록 조회 성공"))
                 .andExpect(jsonPath("$.data[0].id").value(1))
                 .andExpect(jsonPath("$.data[0].content").value("누구에게 선물하나요?"))
-                .andExpect(jsonPath("$.data[0].type").value("CHOICE"))
+                .andExpect(jsonPath("$.data[0].type").value("FIXED"))
                 .andExpect(jsonPath("$.data[0].order").value(1))
                 .andExpect(jsonPath("$.data[0].options[0].content").value("연인"));
     }

--- a/src/test/java/com/example/giftrecommender/controller/UserAnswerControllerTest.java
+++ b/src/test/java/com/example/giftrecommender/controller/UserAnswerControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.giftrecommender.controller;
 
 import com.example.giftrecommender.common.logging.LogEventService;
+import com.example.giftrecommender.domain.enums.AnswerOptionType;
 import com.example.giftrecommender.domain.enums.QuestionType;
 import com.example.giftrecommender.dto.request.UserAnswerRequestDto;
 import com.example.giftrecommender.service.UserAnswerService;
@@ -22,21 +23,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @ActiveProfiles("test")
 @WebMvcTest(UserAnswerController.class)
 class UserAnswerControllerTest {
 
     @Autowired private MockMvc mockMvc;
-
     @Autowired private ObjectMapper objectMapper;
 
     @MockBean private UserAnswerService userAnswerService;
-
     @MockBean private LogEventService logEventService;
 
     private UUID guestId;
-
     private UUID sessionId;
 
     @BeforeEach
@@ -45,11 +42,18 @@ class UserAnswerControllerTest {
         sessionId = UUID.randomUUID();
     }
 
-    @DisplayName("POST /answers - 유저 응답 저장 성공")
+    @DisplayName("POST /answers - 유저 응답 저장 성공 (선택형)")
     @Test
-    void saveUserAnswerSuccess() throws Exception {
+    void saveUserAnswerSuccess_choice() throws Exception {
         // given
-        UserAnswerRequestDto requestDto = new UserAnswerRequestDto(1L, QuestionType.CHOICE,1L);
+        UserAnswerRequestDto requestDto = new UserAnswerRequestDto(
+                1L,
+                QuestionType.FIXED,
+                AnswerOptionType.CHOICE,
+                1L,
+                null
+        );
+
         doNothing().when(userAnswerService).saveAnswer(guestId, sessionId, requestDto);
 
         // when & then
@@ -61,4 +65,26 @@ class UserAnswerControllerTest {
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
 
+    @DisplayName("POST /answers - 유저 응답 저장 성공 (직접입력형)")
+    @Test
+    void saveUserAnswerSuccess_text() throws Exception {
+        // given
+        UserAnswerRequestDto requestDto = new UserAnswerRequestDto(
+                2L,
+                QuestionType.FIXED,
+                AnswerOptionType.TEXT,
+                null,
+                "직접 입력한 답변"
+        );
+
+        doNothing().when(userAnswerService).saveAnswer(guestId, sessionId, requestDto);
+
+        // when & then
+        mockMvc.perform(post("/api/guests/{guestId}/recommendation-sessions/{sessionId}/answers", guestId, sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("응답 저장"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
 }

--- a/src/test/java/com/example/giftrecommender/domain/entity/UserAnswerTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/entity/UserAnswerTest.java
@@ -4,6 +4,7 @@ import com.example.giftrecommender.domain.entity.answer_option.AiAnswerOption;
 import com.example.giftrecommender.domain.entity.answer_option.AnswerOption;
 import com.example.giftrecommender.domain.entity.question.AiQuestion;
 import com.example.giftrecommender.domain.entity.question.Question;
+import com.example.giftrecommender.domain.enums.AnswerOptionType;
 import com.example.giftrecommender.domain.enums.QuestionType;
 import com.example.giftrecommender.domain.enums.SessionStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -25,16 +26,25 @@ class UserAnswerTest {
         RecommendationSession session = createRecommendationSession(guest);
         Question question = Question.builder()
                 .content("이건 고정 질문입니다")
-                .type(QuestionType.CHOICE)
+                .type(QuestionType.FIXED)
                 .order(1)
                 .build();
         AnswerOption option = AnswerOption.builder()
                 .content("이건 선택지입니다")
                 .question(question)
                 .build();
+        String answerText = "이건 선택지입니다";
 
         // when
-        UserAnswer answer = UserAnswer.ofFixed(guest, session, question, option, QuestionType.CHOICE);
+        UserAnswer answer = UserAnswer.ofFixed(
+                guest,
+                session,
+                question,
+                option,
+                QuestionType.FIXED,
+                AnswerOptionType.CHOICE,
+                answerText
+        );
 
         // then
         assertThat(answer).isNotNull();
@@ -42,16 +52,9 @@ class UserAnswerTest {
         assertThat(answer.getRecommendationSession()).isEqualTo(session);
         assertThat(answer.getQuestion()).isEqualTo(question);
         assertThat(answer.getAnswerOption()).isEqualTo(option);
-        assertThat(answer.getType()).isEqualTo(QuestionType.CHOICE);
-    }
-
-    private static RecommendationSession createRecommendationSession(Guest guest) {
-        RecommendationSession session = RecommendationSession.builder()
-                .id(UUID.randomUUID())
-                .guest(guest)
-                .status(SessionStatus.PENDING)
-                .build();
-        return session;
+        assertThat(answer.getQuestionType()).isEqualTo(QuestionType.FIXED);
+        assertThat(answer.getAnswerOptionType()).isEqualTo(AnswerOptionType.CHOICE);
+        assertThat(answer.getAnswerText()).isEqualTo(answerText);
     }
 
     @DisplayName("GPT 질문용 ofAi 생성자 테스트")
@@ -64,7 +67,7 @@ class UserAnswerTest {
                 .guest(guest)
                 .session(session)
                 .content("AI 질문입니다")
-                .type(QuestionType.CHOICE)
+                .type(QuestionType.AI)
                 .order(4)
                 .build();
         AiAnswerOption aiAnswerOption = AiAnswerOption.builder()
@@ -72,9 +75,18 @@ class UserAnswerTest {
                 .content("GPT가 추천한 답변")
                 .selectedIndex(1)
                 .build();
+        String answerText = "GPT가 추천한 답변";
 
         // when
-        UserAnswer answer = UserAnswer.ofAi(guest, session, aiQuestion, aiAnswerOption, QuestionType.CHOICE);
+        UserAnswer answer = UserAnswer.ofAi(
+                guest,
+                session,
+                aiQuestion,
+                aiAnswerOption,
+                QuestionType.AI,
+                AnswerOptionType.CHOICE,
+                answerText
+        );
 
         // then
         assertThat(answer).isNotNull();
@@ -82,7 +94,16 @@ class UserAnswerTest {
         assertThat(answer.getRecommendationSession()).isEqualTo(session);
         assertThat(answer.getAiQuestion()).isEqualTo(aiQuestion);
         assertThat(answer.getAiAnswerOption()).isEqualTo(aiAnswerOption);
-        assertThat(answer.getType()).isEqualTo(QuestionType.CHOICE);
+        assertThat(answer.getQuestionType()).isEqualTo(QuestionType.AI);
+        assertThat(answer.getAnswerOptionType()).isEqualTo(AnswerOptionType.CHOICE);
+        assertThat(answer.getAnswerText()).isEqualTo(answerText);
     }
 
+    private static RecommendationSession createRecommendationSession(Guest guest) {
+        return RecommendationSession.builder()
+                .id(UUID.randomUUID())
+                .guest(guest)
+                .status(SessionStatus.PENDING)
+                .build();
+    }
 }

--- a/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/answer_option/AnswerOptionRepositoryTest.java
@@ -34,7 +34,7 @@ class AnswerOptionRepositoryTest {
         question = questionRepository.save(
                 Question.builder()
                         .content("취미는?")
-                        .type(QuestionType.CHOICE)
+                        .type(QuestionType.FIXED)
                         .order(1)
                         .build()
         );

--- a/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
+++ b/src/test/java/com/example/giftrecommender/domain/repository/question/QuestionRepositoryTest.java
@@ -41,7 +41,7 @@ class QuestionRepositoryTest {
     private static Question createQuestion(String content, int order) {
         return Question.builder()
                 .content(content)
-                .type(QuestionType.CHOICE)
+                .type(QuestionType.FIXED)
                 .order(order)
                 .build();
     }

--- a/src/test/java/com/example/giftrecommender/service/QuestionServiceTest.java
+++ b/src/test/java/com/example/giftrecommender/service/QuestionServiceTest.java
@@ -60,7 +60,7 @@ class QuestionServiceTest {
     private Question createQuestion(String content, Integer order) {
         return Question.builder()
                 .content(content)
-                .type(QuestionType.CHOICE)
+                .type(QuestionType.FIXED)
                 .order(order)
                 .build();
     }


### PR DESCRIPTION
### 주요 변경사항
- TEXT(직접입력형) 응답 저장 기능 추가
- `UserAnswer` 엔티티에 `answerText`, `answerOptionType` 필드 추가
- 기존 `QuestionType` 값을 `FIXED`, `AI`로 변경
- `AnswerOptionType` enum 추가 (CHOICE, TEXT)
- `selectedIndex` 필드 타입을 `int → Integer`로 변경 (nullable 처리)
- 요청 DTO 및 컨트롤러 로직 구조 개선
- 서비스 로직에 TEXT 응답 처리 분기 추가
- 관련 단위 테스트 추가 및 기존 테스트 수정
- `INVALID_REQUEST` 예외 코드 추가

### 테스트
- `UserAnswerServiceTest`를 통해 선택형 및 직접입력형 응답 저장 기능 검증 완료
- 컨트롤러 단 테스트(`UserAnswerControllerTest`, `UserAnswerAiControllerTest`) 정상 작동 확인
