### PR TITLE
feat(crawling-product): 관리자 상품 API/DTO/서비스 추가 및 URL 추가

### DIFF
--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -18,7 +18,8 @@ public enum ExceptionEnum {
     RECOMMENDATION_EMPTY(HttpStatus.BAD_REQUEST.value(), "추천 결과가 없습니다. 키워드를 조정하거나 다시 시도해주세요."),
     QUOTA_SECOND_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "잠시 후 다시 시도해주세요. (초당 호출 제한)"),
     QUOTA_DAILY_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 파라미터가 올바르지 않습니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 파라미터가 올바르지 않습니다."),
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상품을 찾을 수 없습니다."),;
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -1,0 +1,89 @@
+package com.example.giftrecommender.controller;
+
+import com.example.giftrecommender.common.BasicResponseDto;
+import com.example.giftrecommender.domain.enums.Age;
+import com.example.giftrecommender.domain.enums.Gender;
+import com.example.giftrecommender.dto.request.ConfirmRequestDto;
+import com.example.giftrecommender.dto.request.CrawlingProductRequestDto;
+import com.example.giftrecommender.dto.request.ScoreRequestDto;
+import com.example.giftrecommender.dto.response.ConfirmResponseDto;
+import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
+import com.example.giftrecommender.dto.response.ScoreResponseDto;
+import com.example.giftrecommender.service.CrawlingProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "크롤링 상품", description = "크롤링 상품 관련 API")
+@RestController
+@RequestMapping("/api/admin/products")
+@RequiredArgsConstructor
+public class CrawlingProductController {
+
+    private final CrawlingProductService crawlingProductService;
+
+    @Operation(summary = "크롤링 상품 저장")
+    @PostMapping
+    public ResponseEntity<BasicResponseDto<CrawlingProductResponseDto>> save(@RequestBody CrawlingProductRequestDto requestDto) {
+        return ResponseEntity.ok(BasicResponseDto.success("크롤링 상품 저장 완료.", crawlingProductService.save(requestDto)));
+    }
+
+    @Operation(summary = "크롤링 상품 여러 건 저장")
+    @PostMapping("/batch")
+    public ResponseEntity<List<CrawlingProductResponseDto>> saveAll(@RequestBody List<CrawlingProductRequestDto> requestDtoList) {
+        return ResponseEntity.ok(crawlingProductService.saveAll(requestDtoList));
+    }
+
+    @Operation(summary = "크롤링 상품 목록 조회 (필터/정렬/페이징)")
+    @GetMapping
+    public ResponseEntity<BasicResponseDto<Page<CrawlingProductResponseDto>>> getProducts(
+            @RequestParam(name = "keyword",     required = false) String keyword,
+            @RequestParam(name = "minPrice",    required = false) Integer minPrice,
+            @RequestParam(name = "maxPrice",    required = false) Integer maxPrice,
+            @RequestParam(name = "category",    required = false) String category,
+            @RequestParam(name = "platform",    required = false) String platform,
+            @RequestParam(name = "sellerName",  required = false) String sellerName,
+            @RequestParam(name = "gender",      required = false) Gender gender,
+            @RequestParam(name = "age",         required = false) Age age,
+            @RequestParam(name = "isConfirmed", required = false) Boolean isConfirmed,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<CrawlingProductResponseDto> page = crawlingProductService.getProducts(
+                keyword, minPrice, maxPrice, category, platform, sellerName, gender, age, isConfirmed, pageable
+        );
+        return ResponseEntity.ok(
+                BasicResponseDto.success("크롤링 상품 목록 조회 완료.", page)
+        );
+    }
+
+    @Operation(summary = "관리자 점수 부여 (adminCheck 자동 true)")
+    @PostMapping("/{product_id}/score")
+    public ResponseEntity<BasicResponseDto<ScoreResponseDto>> giveScore(
+            @PathVariable(name = "product_id") Long productId,
+            @RequestBody ScoreRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(
+                BasicResponseDto.success("관리자 점수 부여 완료.", crawlingProductService.giveScore(productId, requestDto))
+        );
+    }
+
+    @Operation(summary = "관리자 컨펌 상태 변경")
+    @PutMapping("/{product_id}/confirm")
+    public ResponseEntity<BasicResponseDto<ConfirmResponseDto>> updateConfirmStatus(
+            @PathVariable(name = "product_id") Long productId,
+            @RequestBody ConfirmRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(
+                BasicResponseDto.success("관리자 컨펌 상태 변경 완료.", crawlingProductService.updateConfirmStatus(productId, requestDto))
+        );
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
@@ -1,0 +1,140 @@
+package com.example.giftrecommender.domain.entity;
+
+import com.example.giftrecommender.domain.enums.Age;
+import com.example.giftrecommender.domain.enums.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "crawling_product")
+@Getter
+@NoArgsConstructor
+public class CrawlingProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "crawling_product_id")
+    private Long id;
+
+    // 원본 상품명
+    @Column(name = "original_name", nullable = false, length = 255)
+    private String originalName;
+
+    // 사용자에게 표시할 상품명
+    @Column(name = "display_name", nullable = false, length = 255)
+    private String displayName;
+
+    // 가격 (원 단위)
+    @Column(nullable = false)
+    private Integer price;
+
+    // 대표 이미지 URL
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+
+    // 상품 상세 페이지 링크
+    @Column(columnDefinition = "TEXT")
+    private String productUrl;
+
+    // 카테고리명
+    @Column(length = 100)
+    private String category;
+
+    // 검색/추천용 키워드 배열
+    @ElementCollection
+    @CollectionTable(name = "crawling_product_keywords", joinColumns = @JoinColumn(name = "crawling_product_id"))
+    @Column(name = "keyword")
+    private List<String> keywords;
+
+    // 리뷰 개수
+    @Column(name = "review_count")
+    private Integer reviewCount;
+
+    // 별점 (0~5)
+    @Column(precision = 2, scale = 1)
+    private BigDecimal rating;
+
+    // 판매자명
+    @Column(name = "seller_name", length = 100)
+    private String sellerName;
+
+    // 플랫폼명 (예: 텐바이텐, 네이버)
+    @Column(length = 50)
+    private String platform;
+
+    // 점수 (자동 + 수동)
+    @Column
+    private Integer score = 0;
+
+    // 관리자 수동 점수 부여 여부
+    @Column(name = "admin_check")
+    private Boolean adminCheck = false;
+
+    // 성별 태그
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Gender gender = Gender.ANY;
+
+    // 연령대 태그
+    @Enumerated(EnumType.STRING)
+    @Column(length = 15)
+    private Age age = Age.NONE;
+
+    // 관리자 컨펌 여부
+    @Column(name = "is_confirmed")
+    private Boolean isConfirmed = false;
+
+    // 생성/수정 시각
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void addScore(int score) {
+        this.score += score;
+    }
+
+    public void changeAdminCheck(boolean adminCheck) {
+        this.adminCheck = adminCheck;
+    }
+
+    public void changeConfirmed(boolean confirmed) {
+        this.isConfirmed = confirmed;
+    }
+
+    @Builder
+    public CrawlingProduct(String originalName, String displayName, Integer price, String imageUrl,
+                           String productUrl, String category, List<String> keywords, Integer reviewCount,
+                           BigDecimal rating,  Integer score, String sellerName, String platform) {
+        this.originalName = originalName;
+        this.displayName = displayName;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.productUrl = productUrl;
+        this.category = category;
+        this.keywords = keywords;
+        this.reviewCount = reviewCount;
+        this.rating = rating;
+        this.score = score != null ? score : 0;
+        this.sellerName = sellerName;
+        this.platform = platform;
+    }
+}
+

--- a/src/main/java/com/example/giftrecommender/domain/enums/Age.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/Age.java
@@ -1,0 +1,5 @@
+package com.example.giftrecommender.domain.enums;
+
+public enum Age {
+    KID, TEEN, YOUNG_ADULT, SENIOR, NONE
+}

--- a/src/main/java/com/example/giftrecommender/domain/enums/Gender.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.example.giftrecommender.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE, ANY
+}

--- a/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
@@ -1,0 +1,44 @@
+package com.example.giftrecommender.domain.repository;
+
+import com.example.giftrecommender.domain.entity.CrawlingProduct;
+import com.example.giftrecommender.domain.enums.Age;
+import com.example.giftrecommender.domain.enums.Gender;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CrawlingProductRepository extends JpaRepository<CrawlingProduct, Long> {
+
+    @Query("""
+        SELECT p FROM CrawlingProduct p
+        WHERE (:keyword IS NULL OR 
+              p.originalName LIKE CONCAT('%', :keyword, '%') OR
+              p.displayName  LIKE CONCAT('%', :keyword, '%') OR
+              p.sellerName   LIKE CONCAT('%', :keyword, '%') OR
+              p.category     LIKE CONCAT('%', :keyword, '%') OR
+              p.platform     LIKE CONCAT('%', :keyword, '%'))
+          AND (:minPrice IS NULL OR p.price >= :minPrice)
+          AND (:maxPrice IS NULL OR p.price <= :maxPrice)
+          AND (:category IS NULL OR p.category = :category)
+          AND (:platform IS NULL OR p.platform = :platform)
+          AND (:sellerName IS NULL OR p.sellerName = :sellerName)
+          AND (:gender IS NULL OR p.gender = :gender)
+          AND (:age IS NULL OR p.age = :age)
+          AND (:isConfirmed IS NULL OR p.isConfirmed = :isConfirmed)
+        """)
+    Page<CrawlingProduct> search(
+            @Param("keyword") String keyword,
+            @Param("minPrice") Integer minPrice,
+            @Param("maxPrice") Integer maxPrice,
+            @Param("category") String category,
+            @Param("platform") String platform,
+            @Param("sellerName") String sellerName,
+            @Param("gender") Gender gender,
+            @Param("age") Age age,
+            @Param("isConfirmed") Boolean isConfirmed,
+            Pageable pageable
+    );
+
+}

--- a/src/main/java/com/example/giftrecommender/dto/request/ConfirmRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/ConfirmRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ConfirmRequestDto(
+        @Schema(description = "컨펌 여부", example = "true")
+        @NotNull
+        Boolean isConfirmed
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/CrawlingProductRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/CrawlingProductRequestDto.java
@@ -1,0 +1,79 @@
+package com.example.giftrecommender.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CrawlingProductRequestDto(
+
+        @Schema(description = "원본 상품명", example = "[무아스] 마카롱 3구 USB 고용량 큐브 멀티탭 1.5m")
+        @NotBlank
+        String originalName,
+
+        @Schema(description = "가격 (원 단위)", example = "15900")
+        @NotNull
+        @PositiveOrZero
+        Integer price,
+
+        @Schema(description = "대표 이미지 URL", example = "https://image.10x10.co.kr/image1.jpg")
+        @NotBlank
+        String imageUrl,
+
+        @Schema(description = "상품 상세 페이지 URL", example = "https://10x10.co.kr/item/6625336")
+        @NotBlank
+        String productUrl,
+
+        @Schema(description = "카테고리명", example = "디지털/PC")
+        String category,
+
+        @Schema(description = "검색/추천용 키워드 배열", example = "[\"USB\", \"멀티탭\", \"케이블\"]")
+        List<String> keywords,
+
+        @Schema(description = "리뷰 개수", example = "128")
+        Integer reviewCount,
+
+        @Schema(description = "별점 (0~5)", example = "4.8")
+        @DecimalMin(value = "0.0")
+        @DecimalMax(value = "5.0")
+        BigDecimal rating,
+
+        @Schema(description = "판매자명", example = "무무샵")
+        String sellerName,
+
+        @Schema(description = "플랫폼명", example = "텐바이텐")
+        String platform
+
+) {}
+
+/*
+여러건 등록 예시
+[
+  {
+    "originalName": "무아스 큐브 멀티탭",
+    "price": 29000,
+    "imageUrl": "https://example.com/image.jpg",
+    "productUrl": "https://example.com/product",
+    "category": "디자인문구",
+    "keywords": ["멀티탭", "usb", "귀여움"],
+    "reviewCount": 150,
+    "rating": 4.5,
+    "sellerName": "무아스",
+    "platform": "텐바이텐"
+  },
+  {
+    "originalName": "스누피 무드등",
+    "price": 19900,
+    "imageUrl": "https://example.com/snoopy.jpg",
+    "productUrl": "https://example.com/snoopy",
+    "category": "무드등",
+    "keywords": ["조명", "선물", "귀여움"],
+    "reviewCount": 80,
+    "rating": 4.2,
+    "sellerName": "라이팅샵",
+    "platform": "네이버"
+  }
+]
+
+ */

--- a/src/main/java/com/example/giftrecommender/dto/request/ScoreRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/ScoreRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.giftrecommender.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ScoreRequestDto(
+        @Schema(description = "관리자 수동 점수", example = "10")
+        @NotNull @PositiveOrZero
+        Integer score
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/ConfirmResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/ConfirmResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.giftrecommender.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ConfirmResponseDto(
+        @Schema(description = "상품 ID") Long id,
+        @Schema(description = "컨펌 여부") Boolean isConfirmed,
+        @Schema(description = "수정 시각") LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/CrawlingProductResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/CrawlingProductResponseDto.java
@@ -1,0 +1,70 @@
+package com.example.giftrecommender.dto.response;
+
+import com.example.giftrecommender.domain.enums.Age;
+import com.example.giftrecommender.domain.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CrawlingProductResponseDto(
+
+        @Schema(description = "상품 ID", example = "1")
+        Long id,
+
+        @Schema(description = "원본 상품명", example = "[무아스] 마카롱 3구 USB 고용량 큐브 멀티탭 1.5m")
+        String originalName,
+
+        @Schema(description = "사용자에게 표시할 상품명", example = "USB 멀티탭 3구")
+        String displayName,
+
+        @Schema(description = "가격 (원 단위)", example = "15900")
+        Integer price,
+
+        @Schema(description = "대표 이미지 URL", example = "https://image.10x10.co.kr/image1.jpg")
+        String imageUrl,
+
+        @Schema(description = "상품 상세 페이지 URL", example = "https://10x10.co.kr/item/6625336")
+        String productUrl,
+
+        @Schema(description = "카테고리명", example = "디지털/PC")
+        String category,
+
+        @Schema(description = "검색/추천용 키워드 배열", example = "[\"USB\", \"멀티탭\", \"케이블\"]")
+        List<String> keywords,
+
+        @Schema(description = "리뷰 개수", example = "128")
+        Integer reviewCount,
+
+        @Schema(description = "별점 (0~5)", example = "4.8")
+        BigDecimal rating,
+
+        @Schema(description = "판매자명", example = "무무샵")
+        String sellerName,
+
+        @Schema(description = "플랫폼명", example = "텐바이텐")
+        String platform,
+
+        @Schema(description = "자동점수 + 수동점수 총합", example = "12")
+        Integer score,
+
+        @Schema(description = "관리자 수동 점수 부여 여부", example = "false")
+        Boolean adminCheck,
+
+        @Schema(description = "성별 태그", example = "female")
+        Gender gender,
+
+        @Schema(description = "연령대 태그", example = "young_adult")
+        Age age,
+
+        @Schema(description = "관리자 컨펌 여부", example = "false")
+        Boolean isConfirmed,
+
+        @Schema(description = "생성 시각", example = "2025-08-07T12:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정 시각", example = "2025-08-07T12:10:00")
+        LocalDateTime updatedAt
+
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/ScoreResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/ScoreResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.giftrecommender.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record ScoreResponseDto(
+        @Schema(description = "상품 ID") Long id,
+        @Schema(description = "최종 점수") Integer score,
+        @Schema(description = "관리자 점수 여부") Boolean adminCheck,
+        @Schema(description = "컨펌 여부") Boolean isConfirmed,
+        @Schema(description = "수정 시각") LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/example/giftrecommender/mapper/CrawlingProductMapper.java
+++ b/src/main/java/com/example/giftrecommender/mapper/CrawlingProductMapper.java
@@ -1,0 +1,31 @@
+package com.example.giftrecommender.mapper;
+
+import com.example.giftrecommender.domain.entity.CrawlingProduct;
+import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
+
+public class CrawlingProductMapper {
+
+    public static CrawlingProductResponseDto toDto(CrawlingProduct product) {
+        return new CrawlingProductResponseDto(
+                product.getId(),
+                product.getOriginalName(),
+                product.getDisplayName(),
+                product.getPrice(),
+                product.getImageUrl(),
+                product.getProductUrl(),
+                product.getCategory(),
+                product.getKeywords(),
+                product.getReviewCount(),
+                product.getRating(),
+                product.getSellerName(),
+                product.getPlatform(),
+                product.getScore(),
+                product.getAdminCheck(),
+                product.getGender(),
+                product.getAge(),
+                product.getIsConfirmed(),
+                product.getCreatedAt(),
+                product.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/example/giftrecommender/service/CrawlingProductService.java
+++ b/src/main/java/com/example/giftrecommender/service/CrawlingProductService.java
@@ -1,0 +1,193 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.common.exception.ErrorException;
+import com.example.giftrecommender.common.exception.ExceptionEnum;
+import com.example.giftrecommender.domain.entity.CrawlingProduct;
+import com.example.giftrecommender.domain.enums.Age;
+import com.example.giftrecommender.domain.enums.Gender;
+import com.example.giftrecommender.domain.repository.CrawlingProductRepository;
+import com.example.giftrecommender.dto.request.ConfirmRequestDto;
+import com.example.giftrecommender.dto.request.CrawlingProductRequestDto;
+import com.example.giftrecommender.dto.request.ScoreRequestDto;
+import com.example.giftrecommender.dto.response.ConfirmResponseDto;
+import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
+import com.example.giftrecommender.dto.response.ScoreResponseDto;
+import com.example.giftrecommender.mapper.CrawlingProductMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CrawlingProductService {
+
+    private final CrawlingProductRepository crawlingProductRepository;
+
+    /**
+     * 단건 저장
+     */
+    @Transactional
+    public CrawlingProductResponseDto save(CrawlingProductRequestDto requestDto) {
+        int score = calculateScore(requestDto.rating(), requestDto.reviewCount());
+
+        CrawlingProduct product = CrawlingProduct.builder()
+                .originalName(requestDto.originalName())
+                .displayName(generateDisplayName(requestDto.originalName())) // 노출용 이름 생성
+                .price(requestDto.price())
+                .imageUrl(requestDto.imageUrl())
+                .productUrl(requestDto.productUrl())
+                .category(requestDto.category())
+                .keywords(requestDto.keywords())
+                .reviewCount(requestDto.reviewCount())
+                .rating(requestDto.rating())
+                .score(score)
+                .sellerName(requestDto.sellerName())
+                .platform(requestDto.platform())
+                .build();
+
+        CrawlingProduct savedProduct = crawlingProductRepository.save(product);
+        return CrawlingProductMapper.toDto(savedProduct);
+    }
+
+    /**
+     * 여러건 저장
+     */
+    @Transactional
+    public List<CrawlingProductResponseDto> saveAll(List<CrawlingProductRequestDto> requestDtoList) {
+        List<CrawlingProduct> products = requestDtoList.stream()
+                .map(dto -> {
+                    int score = calculateScore(dto.rating(), dto.reviewCount());
+                    return CrawlingProduct.builder()
+                            .originalName(dto.originalName())
+                            .displayName(generateDisplayName(dto.originalName()))
+                            .price(dto.price())
+                            .imageUrl(dto.imageUrl())
+                            .productUrl(dto.productUrl())
+                            .category(dto.category())
+                            .keywords(dto.keywords())
+                            .reviewCount(dto.reviewCount())
+                            .rating(dto.rating())
+                            .sellerName(dto.sellerName())
+                            .platform(dto.platform())
+                            .score(score)
+                            .build();
+                })
+                .toList();
+
+        List<CrawlingProduct> savedList = crawlingProductRepository.saveAll(products);
+        return savedList.stream()
+                .map(CrawlingProductMapper::toDto)
+                .toList();
+    }
+
+    /**
+     * 페이징 조회 + 동적 검색
+     */
+    @Transactional(readOnly = true)
+    public Page<CrawlingProductResponseDto> getProducts(
+            String keyword,
+            Integer minPrice,
+            Integer maxPrice,
+            String category,
+            String platform,
+            String sellerName,
+            Gender gender,
+            Age age,
+            Boolean isConfirmed,
+            Pageable pageable
+    ) {
+        Page<CrawlingProduct> page = crawlingProductRepository.search(
+                keyword, minPrice, maxPrice, category, platform, sellerName, gender, age, isConfirmed, pageable
+        );
+
+        return page.map(CrawlingProductMapper::toDto);
+    }
+
+    /*
+     * 점수 부여 + adminCheck true
+     */
+    @Transactional
+    public ScoreResponseDto giveScore(Long productId, ScoreRequestDto requestDto) {
+        CrawlingProduct product = crawlingProductRepository.findById(productId)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.PRODUCT_NOT_FOUND));
+
+        product.addScore(requestDto.score());
+        product.changeAdminCheck(true);
+
+        return new ScoreResponseDto(
+                product.getId(),
+                product.getScore(),
+                product.getAdminCheck(),
+                product.getIsConfirmed(),
+                product.getUpdatedAt()
+        );
+    }
+
+    /*
+     * 컨펌 상태 변경
+     */
+    @Transactional
+    public ConfirmResponseDto updateConfirmStatus(Long productId, ConfirmRequestDto requestDto) {
+        CrawlingProduct product = crawlingProductRepository.findById(productId)
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.PRODUCT_NOT_FOUND));
+
+        product.changeConfirmed(requestDto.isConfirmed());
+
+        return new ConfirmResponseDto(
+                product.getId(),
+                product.getIsConfirmed(),
+                product.getUpdatedAt()
+        );
+    }
+
+    private int calculateScore(BigDecimal rating, Integer reviewCount) {
+        int score = 0;
+        if (rating != null && rating.compareTo(BigDecimal.valueOf(4.2)) >= 0) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 100) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 1000 && rating != null && rating.compareTo(BigDecimal.valueOf(4.5)) >= 0) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 10000 && rating != null && rating.compareTo(BigDecimal.valueOf(4.3)) >= 0) {
+            score += 1;
+        }
+        return score;
+    }
+
+    private String generateDisplayName(String originalName) {
+        if (originalName == null) return null;
+
+        String name = originalName;
+
+        // 대괄호, 소괄호, 중괄호 안 내용 제거
+        name = name.replaceAll("\\[.*?\\]", "")
+                .replaceAll("\\(.*?\\)", "")
+                .replaceAll("\\{.*?\\}", "");
+
+        // 특수문자/장식 기호 제거
+        name = name.replaceAll("[★♥●◆◎※]", "");
+
+        // 불필요한 키워드 제거
+        String[] removeKeywords = {
+                "무료배송", "빠른배송", "사은품", "당일발송",
+                "세트", "세트상품", "1\\+1", "2\\+1", "3\\+1",
+                "인기", "추천", "HOT", "Best", "BEST", "신상품"
+        };
+        for (String keyword : removeKeywords) {
+            name = name.replaceAll("(?i)" + keyword, ""); // 대소문자 무시
+        }
+
+        // 앞뒤 공백 및 중복 공백 제거
+        name = name.trim().replaceAll("\\s{2,}", " ");
+
+        return name;
+    }
+}


### PR DESCRIPTION
## 목표
- 관리자 상품 CRUD + 점수/컨펌 기능 전면 추가
- 엔드포인트를 설계 문서에 맞게 `/api/admin/products`로 일원화
- 단건/배치 분리, 동적 검색 + 페이징/정렬 지원

## 주요 변경
- **DTO 추가**
  - `CrawlingProductRequestDto`, `CrawlingProductResponseDto`
  - `ScoreRequestDto`, `ScoreResponseDto`
  - `ConfirmRequestDto`, `ConfirmResponseDto`

- **Controller**
  - `POST /api/admin/products` 단건 저장
  - `POST /api/admin/products/batch` 일괄 저장
  - `GET /api/admin/products` 목록 조회(필터/정렬/페이징)
  - `POST /api/admin/products/{product_id}/score` 점수 가산(=adminCheck 자동 true)
  - `PUT /api/admin/products/{product_id}/confirm` 컨펌 상태 변경

- **Service**
  - `save`, `saveAll`: 자동 점수 계산 + `displayName` 생성
  - `getProducts`: 동적 검색 + 페이징
  - `giveScore`: 점수 가산 및 `adminCheck` true
  - `updateConfirmStatus`: 컨펌 상태 변경

- **Repository**
  - `CrawlingProductRepository.search(...)` JPQL 동적 조건 + `Pageable`

- **Mapper**
  - `CrawlingProduct → CrawlingProductResponseDto` 매핑 추가

- **예외**
  - `PRODUCT_NOT_FOUND`(400) 추가

## 테스트/확인
- Swagger로 단건/배치 저장, 목록 조회(정렬/필터), 점수/컨펌 플로우 수동 검증
- 기본 정렬: `createdAt,desc` (PageableDefault)