### PR TITLE
feat(crawling-product): 컨펌 일괄 변경 API 추가 및 정렬 기능 추가

### DIFF
--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -3,9 +3,11 @@ package com.example.giftrecommender.controller;
 import com.example.giftrecommender.common.BasicResponseDto;
 import com.example.giftrecommender.domain.enums.Age;
 import com.example.giftrecommender.domain.enums.Gender;
+import com.example.giftrecommender.dto.request.ConfirmBulkRequestDto;
 import com.example.giftrecommender.dto.request.ConfirmRequestDto;
 import com.example.giftrecommender.dto.request.CrawlingProductRequestDto;
 import com.example.giftrecommender.dto.request.ScoreRequestDto;
+import com.example.giftrecommender.dto.response.ConfirmBulkResponseDto;
 import com.example.giftrecommender.dto.response.ConfirmResponseDto;
 import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
 import com.example.giftrecommender.dto.response.ScoreResponseDto;
@@ -37,7 +39,7 @@ public class CrawlingProductController {
     }
 
     @Operation(summary = "크롤링 상품 여러 건 저장")
-    @PostMapping("/batch")
+    @PostMapping("/bulk")
     public ResponseEntity<List<CrawlingProductResponseDto>> saveAll(@RequestBody List<CrawlingProductRequestDto> requestDtoList) {
         return ResponseEntity.ok(crawlingProductService.saveAll(requestDtoList));
     }
@@ -83,6 +85,17 @@ public class CrawlingProductController {
     ) {
         return ResponseEntity.ok(
                 BasicResponseDto.success("관리자 컨펌 상태 변경 완료.", crawlingProductService.updateConfirmStatus(productId, requestDto))
+        );
+    }
+
+    @Operation(summary = "관리자 컨펌 상태 일괄 변경")
+    @PutMapping("/confirm/bulk")
+    public ResponseEntity<BasicResponseDto<ConfirmBulkResponseDto>> updateConfirmStatusBulk(
+            @RequestBody ConfirmBulkRequestDto request
+    ) {
+        ConfirmBulkResponseDto result = crawlingProductService.updateConfirmStatusBulk(request);
+        return ResponseEntity.ok(
+                BasicResponseDto.success("관리자 컨펌 상태 일괄 변경 완료.", result)
         );
     }
 

--- a/src/main/java/com/example/giftrecommender/domain/enums/ProductSort.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/ProductSort.java
@@ -1,0 +1,35 @@
+package com.example.giftrecommender.domain.enums;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+import java.util.EnumSet;
+
+@Getter
+public enum ProductSort {
+    SCORE("score"),
+    PRICE("price"),
+    REVIEW_COUNT("reviewCount"),
+    RATING("rating"),
+    IS_CONFIRMED("isConfirmed"),
+    CREATED_AT("createdAt"),
+    UPDATED_AT("updatedAt");
+
+    private final String field;
+
+    ProductSort(String field) {
+        this.field = field;
+    }
+
+    public static boolean isAllowed(String property) {
+        for (ProductSort ps : EnumSet.allOf(ProductSort.class)) {
+            if (ps.field.equals(property)) return true;
+        }
+        return false;
+    }
+
+    public static Sort defaultSort() {
+        return Sort.by(Sort.Order.desc(CREATED_AT.field));
+    }
+}
+

--- a/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
@@ -6,8 +6,11 @@ import com.example.giftrecommender.domain.enums.Gender;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CrawlingProductRepository extends JpaRepository<CrawlingProduct, Long> {
 
@@ -40,5 +43,14 @@ public interface CrawlingProductRepository extends JpaRepository<CrawlingProduct
             @Param("isConfirmed") Boolean isConfirmed,
             Pageable pageable
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+      UPDATE CrawlingProduct p
+         SET p.isConfirmed = :isConfirmed,
+             p.updatedAt = CURRENT_TIMESTAMP
+       WHERE p.id IN :ids
+    """)
+    int bulkUpdateConfirm(@Param("ids") List<Long> ids, @Param("isConfirmed") boolean isConfirmed);
 
 }

--- a/src/main/java/com/example/giftrecommender/dto/request/ConfirmBulkRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/ConfirmBulkRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.giftrecommender.dto.request;
+
+import java.util.List;
+
+public record ConfirmBulkRequestDto(
+        List<Long> ids,
+        Boolean isConfirmed
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/ConfirmBulkResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/ConfirmBulkResponseDto.java
@@ -1,0 +1,8 @@
+package com.example.giftrecommender.dto.response;
+
+import java.util.List;
+
+public record ConfirmBulkResponseDto(
+        int updatedCount,
+        List<Long> updatedIds
+) {}


### PR DESCRIPTION
## 주요 변경
- **DTO**
  - `ConfirmBulkRequestDto { ids, isConfirmed }`
  - `ConfirmBulkResponseDto { updatedCount, updatedIds }`

- **Repository**
  - `bulkUpdateConfirm(ids, isConfirmed)`: JPQL 일괄 업데이트

- **Service**
  - `updateConfirmStatusBulk(...)`: 일괄 컨펌 변경, 영향 건수 검증(불일치 시 `PRODUCT_NOT_FOUND`)
  - `normalizeSort(Pageable)`: 허용 정렬만 반영, 비어있으면 `createdAt DESC` 기본값 및 2차 정렬 보장

- **Controller**
  - `PUT /api/admin/products/confirm/bulk`: 컨펌 상태 일괄 변경 엔드포인트 추가

- **Common**
  - `ProductSort` enum 추가: `SCORE, PRICE, REVIEW_COUNT, RATING, IS_CONFIRMED, CREATED_AT, UPDATED_AT`
  - 허용 필드 검증 메서드 `isAllowed`, 기본 정렬 `defaultSort()`

## 테스트/검증
- Swagger로 단건/일괄 컨펌 플로우 수동 검증
- 정렬 파라미터 허용/비허용 케이스 점검(`createdAt` 2차 정렬 확인)