### PR TITLE
feat(crawling-product): 상품 연령대 및 성별 단건/일괄 변경 기능 추가

### DIFF
--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -3,17 +3,24 @@ package com.example.giftrecommender.controller;
 import com.example.giftrecommender.common.BasicResponseDto;
 import com.example.giftrecommender.domain.enums.Age;
 import com.example.giftrecommender.domain.enums.Gender;
-import com.example.giftrecommender.dto.request.ConfirmBulkRequestDto;
-import com.example.giftrecommender.dto.request.ConfirmRequestDto;
-import com.example.giftrecommender.dto.request.CrawlingProductRequestDto;
-import com.example.giftrecommender.dto.request.ScoreRequestDto;
-import com.example.giftrecommender.dto.response.ConfirmBulkResponseDto;
-import com.example.giftrecommender.dto.response.ConfirmResponseDto;
-import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
-import com.example.giftrecommender.dto.response.ScoreResponseDto;
+import com.example.giftrecommender.dto.request.*;
+import com.example.giftrecommender.dto.request.age.AgeBulkRequestDto;
+import com.example.giftrecommender.dto.request.age.AgeRequestDto;
+import com.example.giftrecommender.dto.request.confirm.ConfirmBulkRequestDto;
+import com.example.giftrecommender.dto.request.confirm.ConfirmRequestDto;
+import com.example.giftrecommender.dto.request.gender.GenderBulkRequestDto;
+import com.example.giftrecommender.dto.request.gender.GenderRequestDto;
+import com.example.giftrecommender.dto.response.*;
+import com.example.giftrecommender.dto.response.age.AgeBulkResponseDto;
+import com.example.giftrecommender.dto.response.age.AgeResponseDto;
+import com.example.giftrecommender.dto.response.confirm.ConfirmBulkResponseDto;
+import com.example.giftrecommender.dto.response.confirm.ConfirmResponseDto;
+import com.example.giftrecommender.dto.response.gender.GenderBulkResponseDto;
+import com.example.giftrecommender.dto.response.gender.GenderResponseDto;
 import com.example.giftrecommender.service.CrawlingProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,6 +104,42 @@ public class CrawlingProductController {
         return ResponseEntity.ok(
                 BasicResponseDto.success("관리자 컨펌 상태 일괄 변경 완료.", result)
         );
+    }
+
+    @Operation(summary = "상품 연령대 단건 변경")
+    @PutMapping("/age")
+    public ResponseEntity<BasicResponseDto<AgeResponseDto>> updateAge(
+            @Valid @RequestBody AgeRequestDto request
+    ) {
+        AgeResponseDto result = crawlingProductService.updateAge(request);
+        return ResponseEntity.ok(BasicResponseDto.success("연령대 변경 완료", result));
+    }
+
+    @Operation(summary = "상품 연령대 일괄 변경")
+    @PutMapping("/age/bulk")
+    public ResponseEntity<BasicResponseDto<AgeBulkResponseDto>> updateAgeBulk(
+            @Valid @RequestBody AgeBulkRequestDto request
+    ) {
+        AgeBulkResponseDto result = crawlingProductService.updateAgeBulk(request);
+        return ResponseEntity.ok(BasicResponseDto.success("연령대 일괄 변경 완료", result));
+    }
+
+    @Operation(summary = "상품 성별 단건 변경")
+    @PutMapping("/gender")
+    public ResponseEntity<BasicResponseDto<GenderResponseDto>> updateGender(
+            @Valid @RequestBody GenderRequestDto request
+    ) {
+        GenderResponseDto result = crawlingProductService.updateGender(request);
+        return ResponseEntity.ok(BasicResponseDto.success("성별 변경 완료", result));
+    }
+
+    @Operation(summary = "상품 성별 일괄 변경")
+    @PutMapping("/gender/bulk")
+    public ResponseEntity<BasicResponseDto<GenderBulkResponseDto>> updateGenderBulk(
+            @Valid @RequestBody GenderBulkRequestDto request
+    ) {
+        GenderBulkResponseDto result = crawlingProductService.updateGenderBulk(request);
+        return ResponseEntity.ok(BasicResponseDto.success("성별 일괄 변경 완료", result));
     }
 
 }

--- a/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
@@ -119,6 +119,14 @@ public class CrawlingProduct {
         this.isConfirmed = confirmed;
     }
 
+    public void changeAge(Age age) {
+        this.age = age;
+    }
+
+    public void changeGender(Gender gender) {
+        this.gender = gender;
+    }
+
     @Builder
     public CrawlingProduct(String originalName, String displayName, Integer price, String imageUrl,
                            String productUrl, String category, List<String> keywords, Integer reviewCount,

--- a/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
+++ b/src/main/java/com/example/giftrecommender/domain/repository/CrawlingProductRepository.java
@@ -53,4 +53,11 @@ public interface CrawlingProductRepository extends JpaRepository<CrawlingProduct
     """)
     int bulkUpdateConfirm(@Param("ids") List<Long> ids, @Param("isConfirmed") boolean isConfirmed);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update CrawlingProduct p set p.age = :age where p.id in :ids")
+    int bulkUpdateAge(@Param("ids") List<Long> ids, @Param("age") Age age);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update CrawlingProduct p set p.gender = :gender where p.id in :ids")
+    int bulkUpdateGender(@Param("ids") List<Long> ids, @Param("gender") Gender gender);
 }

--- a/src/main/java/com/example/giftrecommender/dto/request/age/AgeBulkRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/age/AgeBulkRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.giftrecommender.dto.request.age;
+
+import com.example.giftrecommender.domain.enums.Age;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "상품 연령대(Age) 일괄 변경 요청")
+public record AgeBulkRequestDto(
+        @Schema(description = "변경할 상품 ID 목록", example = "[1,2]")
+        @NotEmpty List<Long> ids,
+
+        @Schema(description = "변경할 연령대", example = "TEEN")
+        @NotNull Age age
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/age/AgeRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/age/AgeRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.dto.request.age;
+
+import com.example.giftrecommender.domain.enums.Age;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 연령대(Age) 단건 변경 요청")
+public record AgeRequestDto(
+        @Schema(description = "상품 ID", example = "1")
+        @NotNull Long id,
+
+        @Schema(description = "변경할 연령대", example = "YOUNG_ADULT")
+        @NotNull Age age
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/confirm/ConfirmBulkRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/confirm/ConfirmBulkRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto.request;
+package com.example.giftrecommender.dto.request.confirm;
 
 import java.util.List;
 

--- a/src/main/java/com/example/giftrecommender/dto/request/confirm/ConfirmRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/confirm/ConfirmRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto.request;
+package com.example.giftrecommender.dto.request.confirm;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/example/giftrecommender/dto/request/gender/GenderBulkRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/gender/GenderBulkRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.giftrecommender.dto.request.gender;
+
+import com.example.giftrecommender.domain.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+@Schema(description = "상품 성별(Gender) 일괄 변경 요청")
+public record GenderBulkRequestDto(
+        @Schema(description = "변경할 상품 ID 목록", example = "[1,2]")
+        @NotEmpty List<Long> ids,
+
+        @Schema(description = "변경할 성별", example = "FEMALE")
+        @NotNull Gender gender
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/request/gender/GenderRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/gender/GenderRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.dto.request.gender;
+
+import com.example.giftrecommender.domain.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "상품 성별(Gender) 단건 변경 요청")
+public record GenderRequestDto(
+        @Schema(description = "상품 ID", example = "1")
+        @NotNull Long id,
+
+        @Schema(description = "변경할 성별", example = "MALE")
+        @NotNull Gender gender
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/age/AgeBulkResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/age/AgeBulkResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.giftrecommender.dto.response.age;
+
+
+import com.example.giftrecommender.domain.enums.Age;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "상품 연령대(Age) 일괄 변경 응답")
+public record AgeBulkResponseDto(
+        @Schema(description = "실제 변경된 개수", example = "3") int affected,
+        @Schema(description = "변경 대상 상품 ID 목록", example = "[1,2,3]") List<Long> ids,
+        @Schema(description = "변경된 연령대", example = "TEEN") Age age
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/age/AgeResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/age/AgeResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.response.age;
+
+import com.example.giftrecommender.domain.enums.Age;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 연령대(Age) 단건 변경 응답")
+public record AgeResponseDto(
+        @Schema(description = "상품 ID", example = "123") Long id,
+        @Schema(description = "변경된 연령대", example = "YOUNG_ADULT") Age age
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/confirm/ConfirmBulkResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/confirm/ConfirmBulkResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto.response;
+package com.example.giftrecommender.dto.response.confirm;
 
 import java.util.List;
 

--- a/src/main/java/com/example/giftrecommender/dto/response/confirm/ConfirmResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/confirm/ConfirmResponseDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto.response;
+package com.example.giftrecommender.dto.response.confirm;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/example/giftrecommender/dto/response/gender/GenderBulkResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/gender/GenderBulkResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.giftrecommender.dto.response.gender;
+
+import com.example.giftrecommender.domain.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "상품 성별(Gender) 일괄 변경 응답")
+public record GenderBulkResponseDto(
+        @Schema(description = "실제 변경된 개수", example = "3") int affected,
+        @Schema(description = "변경 대상 상품 ID 목록", example = "[1,2,3]") List<Long> ids,
+        @Schema(description = "변경된 성별", example = "FEMALE") Gender gender
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/gender/GenderResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/gender/GenderResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.dto.response.gender;
+
+import com.example.giftrecommender.domain.enums.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 성별(Gender) 단건 변경 응답")
+public record GenderResponseDto(
+        @Schema(description = "상품 ID", example = "123") Long id,
+        @Schema(description = "변경된 성별", example = "MALE") Gender gender
+) {}


### PR DESCRIPTION
## 주요 변경
### DTO
- `AgeRequestDto { id, age }`, `AgeResponseDto { id, age }`
- `AgeBulkRequestDto { ids, age }`, `AgeBulkResponseDto { affected, ids, age }`
- `GenderRequestDto { id, gender }`, `GenderResponseDto { id, gender }`
- `GenderBulkRequestDto { ids, gender }`, `GenderBulkResponseDto { affected, ids, gender }`

### Repository
- `bulkUpdateAge(ids, age)`: JPQL 벌크 업데이트 메서드 추가
- `bulkUpdateGender(ids, gender)`: JPQL 벌크 업데이트 메서드 추가

### Service
- `updateAge(request)`: 연령대 단건 변경, 존재하지 않으면 `PRODUCT_NOT_FOUND` 예외 발생
- `updateAgeBulk(request)`: 연령대 일괄 변경, 영향 건수 검증(불일치 시 `PRODUCT_NOT_FOUND` 예외 발생)
- `updateGender(request)`: 성별 단건 변경, 존재하지 않으면 `PRODUCT_NOT_FOUND` 예외 발생
- `updateGenderBulk(request)`: 성별 일괄 변경, 영향 건수 검증(불일치 시 `PRODUCT_NOT_FOUND` 예외 발생)

### Common
- `CrawlingProduct` 엔티티에 `changeAge`, `changeGender` 메서드 추가
- `dto.request.*`, `dto.response.*` 패키지 구조 정리

## 테스트 / 검증
- Swagger로 연령대/성별 단건 및 일괄 변경 요청 수동 검증
- 잘못된 ID 요청 시 `PRODUCT_NOT_FOUND` 예외 응답 확인