### PR TITLE
feat(product): 단건 부분 수정 API 추가 (PATCH)

### DIFF
--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -10,6 +10,8 @@ import com.example.giftrecommender.dto.request.confirm.ConfirmBulkRequestDto;
 import com.example.giftrecommender.dto.request.confirm.ConfirmRequestDto;
 import com.example.giftrecommender.dto.request.gender.GenderBulkRequestDto;
 import com.example.giftrecommender.dto.request.gender.GenderRequestDto;
+import com.example.giftrecommender.dto.request.product.CrawlingProductRequestDto;
+import com.example.giftrecommender.dto.request.product.CrawlingProductUpdateRequestDto;
 import com.example.giftrecommender.dto.response.*;
 import com.example.giftrecommender.dto.response.age.AgeBulkResponseDto;
 import com.example.giftrecommender.dto.response.age.AgeResponseDto;
@@ -71,6 +73,15 @@ public class CrawlingProductController {
         return ResponseEntity.ok(
                 BasicResponseDto.success("크롤링 상품 목록 조회 완료.", page)
         );
+    }
+
+    @Operation(summary = "상품 단건 부분 수정 (PATCH)")
+    @PatchMapping("/{product_id}")
+    public ResponseEntity<BasicResponseDto<CrawlingProductResponseDto>> patchProduct(
+            @PathVariable(name = "product_id") Long productId,
+            @Valid @RequestBody CrawlingProductUpdateRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(BasicResponseDto.success("상품이 수정되었습니다.", crawlingProductService.updateProduct(productId, requestDto)));
     }
 
     @Operation(summary = "관리자 점수 부여 (adminCheck 자동 true)")

--- a/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
@@ -126,6 +126,15 @@ public class CrawlingProduct {
     public void changeGender(Gender gender) {
         this.gender = gender;
     }
+    public void changeOriginalName(String originalName) { this.originalName = originalName; }
+    public void changeDisplayName(String displayName) { this.displayName = displayName; }
+    public void changePrice(Integer price) { this.price = price; }
+    public void changeImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+    public void changeProductUrl(String productUrl) { this.productUrl = productUrl; }
+    public void changeCategory(String category) { this.category = category; }
+    public void changeKeywords(List<String> keywords) { this.keywords = keywords; }
+    public void changeSellerName(String sellerName) { this.sellerName = sellerName; }
+    public void changePlatform(String platform) { this.platform = platform; }
 
     @Builder
     public CrawlingProduct(String originalName, String displayName, Integer price, String imageUrl,

--- a/src/main/java/com/example/giftrecommender/dto/request/product/CrawlingProductRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/product/CrawlingProductRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.giftrecommender.dto.request;
+package com.example.giftrecommender.dto.request.product;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;

--- a/src/main/java/com/example/giftrecommender/dto/request/product/CrawlingProductUpdateRequestDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/request/product/CrawlingProductUpdateRequestDto.java
@@ -1,0 +1,46 @@
+package com.example.giftrecommender.dto.request.product;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "상품 단건 부분 수정 요청")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CrawlingProductUpdateRequestDto(
+        @Schema(description = "원본명", example = "[무아스] 마카롱 3구 USB 고용량 큐브 멀티탭 1.5m")
+        @Size(max = 300) String originalName,
+
+        @Schema(description = "가격(원)", example = "17900")
+        @Min(0) Integer price,
+
+        @Schema(description = "이미지 URL")
+        @Size(max = 1000) String imageUrl,
+
+        @Schema(description = "상품 상세 URL")
+        @Size(max = 1000) String productUrl,
+
+        @Schema(description = "카테고리", example = "디지털/PC")
+        @Size(max = 100) String category,
+
+        @Schema(description = "키워드", example = "[\"USB\",\"멀티탭\",\"케이블\",\"블루\"]")
+        List<@NotBlank @Size(max = 30) String> keywords,
+
+        @Schema(description = "판매자명", example = "무무샵")
+        @Size(max = 100) String sellerName,
+
+        @Schema(description = "플랫폼", example = "텐바이텐")
+        @Size(max = 50) String platform,
+
+        @Schema(description = "성별", example = "any", allowableValues = {"male","female","any"})
+        String gender,
+
+        @Schema(description = "연령대", example = "young_adult",
+                allowableValues = {"kid","teen","young_adult","senior","none"})
+        String age,
+
+        @Schema(description = "컨펌 여부", example = "true")
+        Boolean isConfirmed
+) {}


### PR DESCRIPTION
## 주요 변경 사항
### DTO
- `CrawlingProductUpdateRequestDto { originalName, price, imageUrl, productUrl, category, keywords[], sellerName, platform, gender, age, isConfirmed }`
  - `@JsonInclude(NON_NULL)`로 보낸 필드만 반영
  - keywords[] 요소 검증(`@NotBlank`, `@Size(max=30)`)

### Service
- `updateProduct(productId, requestDto)`: 단건 부분 수정, 미전송 필드는 유지
- `originalName` 수신 시 `displayName` 자동 재생성
- `gender`/`age` 파싱 헬퍼(`parseGender`, `parseAge`)로 유효성 처리(잘못된 값은 `INVALID_REQUEST`)

### Controller
- 엔드포인트 추가: PATCH `/api/admin/products/{productId}`

## 테스트 / 검증
- Swagger에서 PATCH 요청으로 부분 필드만 변경되는지 확인
- `originalName` 변경 시 `displayName` 자동 갱신 확인
- `gender`/`age`에 잘못된 값 전달 시 `INVALID_REQUEST` 응답 확인
- 존재하지 않는 `productId` 요청 시 `PRODUCT_NOT_FOUND` 예외 응답 확인