### PR TITLE
refactor: 크롤링 상품 벌크 저장 부분 성공 정책 및 응답 구조 리팩토링

### DIFF
--- a/src/main/java/com/example/giftrecommender/config/WebConfig.java
+++ b/src/main/java/com/example/giftrecommender/config/WebConfig.java
@@ -21,7 +21,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("https://mumusgiftbox.o-r.kr", "https://moomus-gift.vercel.app", "https://moomu-preview.vercel.app")
+                .allowedOrigins(
+                        "https://mumusgiftbox.o-r.kr",
+                        "https://moomus-gift.vercel.app",
+                        "https://moomu-preview.vercel.app",
+                        "chrome-extension://kfijmigfhljdnoimcfnjlbgeadnmlhco")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -19,6 +19,8 @@ import com.example.giftrecommender.dto.response.confirm.ConfirmBulkResponseDto;
 import com.example.giftrecommender.dto.response.confirm.ConfirmResponseDto;
 import com.example.giftrecommender.dto.response.gender.GenderBulkResponseDto;
 import com.example.giftrecommender.dto.response.gender.GenderResponseDto;
+import com.example.giftrecommender.dto.response.product.CrawlingProductBulkSaveResponseDto;
+import com.example.giftrecommender.service.CrawlingProductSaver;
 import com.example.giftrecommender.service.CrawlingProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,17 +42,22 @@ import java.util.List;
 public class CrawlingProductController {
 
     private final CrawlingProductService crawlingProductService;
+    private final CrawlingProductSaver crawlingProductSaver;
 
     @Operation(summary = "크롤링 상품 저장")
     @PostMapping
     public ResponseEntity<BasicResponseDto<CrawlingProductResponseDto>> save(@RequestBody CrawlingProductRequestDto requestDto) {
-        return ResponseEntity.ok(BasicResponseDto.success("크롤링 상품 저장 완료.", crawlingProductService.save(requestDto)));
+        return ResponseEntity.ok(BasicResponseDto.success("크롤링 상품 저장 완료.", crawlingProductSaver.save(requestDto)));
     }
 
-    @Operation(summary = "크롤링 상품 여러 건 저장")
+    @Operation(summary = "크롤링 상품 여러 건 저장(부분 성공 정책)")
     @PostMapping("/bulk")
-    public ResponseEntity<List<CrawlingProductResponseDto>> saveAll(@RequestBody List<CrawlingProductRequestDto> requestDtoList) {
-        return ResponseEntity.ok(crawlingProductService.saveAll(requestDtoList));
+    public ResponseEntity<BasicResponseDto<CrawlingProductBulkSaveResponseDto>> saveAll(
+            @RequestBody List<CrawlingProductRequestDto> requestDtoList
+    ) {
+        return ResponseEntity.ok(
+                BasicResponseDto.success("크롤링 상품 여러 건 저장완료(부분 성공 정책)", crawlingProductService.saveAll(requestDtoList))
+        );
     }
 
     @Operation(summary = "크롤링 상품 목록 조회 (필터/정렬/페이징)")

--- a/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
+++ b/src/main/java/com/example/giftrecommender/domain/entity/CrawlingProduct.java
@@ -37,7 +37,7 @@ public class CrawlingProduct {
     private String imageUrl;
 
     // 상품 상세 페이지 링크
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "product_url", nullable = false, length = 512, unique = true)
     private String productUrl;
 
     // 카테고리명

--- a/src/main/java/com/example/giftrecommender/domain/enums/BulkStatus.java
+++ b/src/main/java/com/example/giftrecommender/domain/enums/BulkStatus.java
@@ -1,0 +1,10 @@
+package com.example.giftrecommender.domain.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "벌크 저장 시 각 항목 처리 상태")
+public enum BulkStatus {
+    @Schema(description = "정상 저장") SUCCESS,
+    @Schema(description = "중복으로 저장 안됨") DUPLICATED,
+    @Schema(description = "그 외 실패") FAILED
+}

--- a/src/main/java/com/example/giftrecommender/dto/response/product/BulkItemResultDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/product/BulkItemResultDto.java
@@ -1,0 +1,15 @@
+package com.example.giftrecommender.dto.response.product;
+
+import com.example.giftrecommender.domain.enums.BulkStatus;
+import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "벌크 저장 시 개별 항목 처리 결과")
+public record BulkItemResultDto(
+        @Schema(description = "요청 상품 URL") String url,
+        @Schema(description = "처리 상태") BulkStatus status,
+        @Schema(description = "사유 코드 (예: DUPLICATE_KEY, VALIDATION_ERROR)") String reasonCode,
+        @Schema(description = "사유 메시지 (사용자 친화)") String reasonMessage,
+        @Schema(description = "저장된 상품 ID(성공 시만)") Long id,
+        @Schema(description = "성공 시 저장된 상품 상세") CrawlingProductResponseDto data
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/product/BulkSummaryDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/product/BulkSummaryDto.java
@@ -1,0 +1,11 @@
+package com.example.giftrecommender.dto.response.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "벌크 저장 결과 요약")
+public record BulkSummaryDto(
+        int total,
+        int success,
+        int duplicated,
+        int failed
+) {}

--- a/src/main/java/com/example/giftrecommender/dto/response/product/CrawlingProductBulkSaveResponseDto.java
+++ b/src/main/java/com/example/giftrecommender/dto/response/product/CrawlingProductBulkSaveResponseDto.java
@@ -1,0 +1,11 @@
+package com.example.giftrecommender.dto.response.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "크롤링 상품 벌크 저장 최상위 응답")
+public record CrawlingProductBulkSaveResponseDto(
+        BulkSummaryDto summary,
+        List<BulkItemResultDto> results
+) {}

--- a/src/main/java/com/example/giftrecommender/service/CrawlingProductSaver.java
+++ b/src/main/java/com/example/giftrecommender/service/CrawlingProductSaver.java
@@ -1,0 +1,54 @@
+package com.example.giftrecommender.service;
+
+import com.example.giftrecommender.domain.entity.CrawlingProduct;
+import com.example.giftrecommender.domain.repository.CrawlingProductRepository;
+import com.example.giftrecommender.dto.request.product.CrawlingProductRequestDto;
+import com.example.giftrecommender.dto.response.CrawlingProductResponseDto;
+import com.example.giftrecommender.mapper.CrawlingProductMapper;
+import com.example.giftrecommender.util.RecommendationUtil;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CrawlingProductSaver {
+
+    private final CrawlingProductRepository crawlingProductRepository;
+    private final Validator validator;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public CrawlingProductResponseDto save(CrawlingProductRequestDto requestDto) {
+        Set<ConstraintViolation<CrawlingProductRequestDto>> v = validator.validate(requestDto);
+        if (!v.isEmpty()) {
+            throw new ConstraintViolationException(v);
+        }
+
+        int score = RecommendationUtil.calculateScore(requestDto.rating(), requestDto.reviewCount());
+
+        CrawlingProduct product = CrawlingProduct.builder()
+                .originalName(requestDto.originalName())
+                .displayName(RecommendationUtil.generateDisplayName(requestDto.originalName())) // 노출용 이름 생성
+                .price(requestDto.price())
+                .imageUrl(requestDto.imageUrl())
+                .productUrl(requestDto.productUrl())
+                .category(requestDto.category())
+                .keywords(requestDto.keywords())
+                .reviewCount(requestDto.reviewCount())
+                .rating(requestDto.rating())
+                .score(score)
+                .sellerName(requestDto.sellerName())
+                .platform(requestDto.platform())
+                .build();
+
+        CrawlingProduct savedProduct = crawlingProductRepository.save(product);
+        return CrawlingProductMapper.toDto(savedProduct);
+    }
+
+}

--- a/src/main/java/com/example/giftrecommender/util/RecommendationUtil.java
+++ b/src/main/java/com/example/giftrecommender/util/RecommendationUtil.java
@@ -1,5 +1,6 @@
 package com.example.giftrecommender.util;
 
+import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,6 +61,52 @@ public class RecommendationUtil {
 
     public static boolean allowBabyProduct(String title, String age, String reason, String preference) {
         return !isBabyKeywordIncluded(title) || "10대 미만".equals(age) || "출산".equals(reason) || "출산/육아".equals(preference);
+    }
+
+    public static int calculateScore(BigDecimal rating, Integer reviewCount) {
+        int score = 0;
+        if (rating != null && rating.compareTo(BigDecimal.valueOf(4.2)) >= 0) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 100) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 1000 && rating != null && rating.compareTo(BigDecimal.valueOf(4.5)) >= 0) {
+            score += 1;
+        }
+        if (reviewCount != null && reviewCount >= 10000 && rating != null && rating.compareTo(BigDecimal.valueOf(4.3)) >= 0) {
+            score += 1;
+        }
+        return score;
+    }
+
+    public static String generateDisplayName(String originalName) {
+        if (originalName == null) return null;
+
+        String name = originalName;
+
+        // 대괄호, 소괄호, 중괄호 안 내용 제거
+        name = name.replaceAll("\\[.*?\\]", "")
+                .replaceAll("\\(.*?\\)", "")
+                .replaceAll("\\{.*?\\}", "");
+
+        // 특수문자/장식 기호 제거
+        name = name.replaceAll("[★♥●◆◎※]", "");
+
+        // 불필요한 키워드 제거
+        String[] removeKeywords = {
+                "무료배송", "빠른배송", "사은품", "당일발송",
+                "세트", "세트상품", "1\\+1", "2\\+1", "3\\+1",
+                "인기", "추천", "HOT", "Best", "BEST", "신상품"
+        };
+        for (String keyword : removeKeywords) {
+            name = name.replaceAll("(?i)" + keyword, ""); // 대소문자 무시
+        }
+
+        // 앞뒤 공백 및 중복 공백 제거
+        name = name.trim().replaceAll("\\s{2,}", " ");
+
+        return name;
     }
 
 }


### PR DESCRIPTION
## 주요 변경 사항
### DTO
- **BulkStatus**: SUCCESS, DUPLICATED, FAILED 상태 정의
- **BulkItemResultDto**: url, status, reasonCode, reasonMessage, id, data 포함
- **BulkSummaryDto**: 총 건수, 성공/중복/실패 건수 요약
- **CrawlingProductBulkSaveResponseDto**: summary + results 응답 구조

### Service
- `CrawlingProductService.saveAll()`
  - `@Transactional(propagation = NOT_SUPPORTED)` 적용
  - 각 항목을 `CrawlingProductSaver.save()` (`REQUIRES_NEW`)로 위임하여 부분 성공 정책 구현
  - 예외 유형별 처리
    - VALIDATION_ERROR: Bean Validation 위반
    - DUPLICATE_KEY: DB 유니크 키 충돌 (내부 UK 명칭은 숨기고 사용자 친화 메시지 제공)
    - INTEGRITY_VIOLATION, TRANSACTION_ERROR, ROLLBACK, UNEXPECTED_ERROR 등 표준화된 reasonCode/Message 반환

- `CrawlingProductSaver` 클래스 분리
  - 단건 저장 책임 분리, `REQUIRES_NEW` 트랜잭션으로 실행
  - `RecommendationUtil.calculateScore`, `RecommendationUtil.generateDisplayName` 활용

### Util
- **RecommendationUtil**
  - `calculateScore(rating, reviewCount)` 점수 계산 로직 정규화
  - `generateDisplayName(originalName)` 상품 노출명 정제 로직 정규화

### Controller
- **API 응답 구조 변경**
  - 기존: `List<CrawlingProductResponseDto>`
  - 변경: `BasicResponseDto<CrawlingProductBulkSaveResponseDto>`
  - 성공/중복/실패 결과를 모두 담은 부분 성공 정책으로 개선
- Swagger summary에 `(부분 성공 정책)` 명시

### 테스트 / 검증
- Swagger에서 `/bulk` API 호출 시
  - 일부 성공/일부 중복/일부 실패가 올바르게 집계되는지 확인
  - 중복 발생 시 내부 DB 키 이름이 아닌 `DUPLICATE_KEY` + 사용자 메시지 노출되는지 확인
  - Validation 실패 시 필드별 상세 메시지가 `reasonMessage`에 매핑되는지 확인