### PR TITLE
feat: 상품 삭제 이벤트 기반 벡터 삭제 처리

### DIFF
--- a/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/giftrecommender/common/exception/ExceptionEnum.java
@@ -19,7 +19,8 @@ public enum ExceptionEnum {
     QUOTA_SECOND_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "잠시 후 다시 시도해주세요. (초당 호출 제한)"),
     QUOTA_DAILY_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS.value(), "오늘은 더 이상 호출할 수 없습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST.value(), "요청 파라미터가 올바르지 않습니다."),
-    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상품을 찾을 수 없습니다."),;
+    PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상품을 찾을 수 없습니다."),
+    VECTOR_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "상품 벡터 삭제에 실패했습니다.");
 
 
     private final int statusCode;

--- a/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
+++ b/src/main/java/com/example/giftrecommender/controller/CrawlingProductController.java
@@ -247,7 +247,7 @@ public class CrawlingProductController {
                 - 전체 상품 개수
                 """
     )
-    @GetMapping("/admin/stats/keyword")
+    @GetMapping("/stats/keyword")
     public ResponseEntity<BasicResponseDto<KeywordStatsResponse>> getKeywordStats(
             @Parameter(description = "조회할 키워드", example = "운동화")
             @RequestParam("keyword") String keyword
@@ -259,6 +259,21 @@ public class CrawlingProductController {
                         "키워드 통계가 성공적으로 조회되었습니다.",
                         response
                 )
+        );
+    }
+
+    @Operation(
+            summary = "상품 삭제 API",
+            description = "상품 ID를 기준으로 상품을 삭제합니다."
+    )
+    @DeleteMapping("/{product_id}")
+    public ResponseEntity<BasicResponseDto<Void>> deleteProduct(
+            @PathVariable("product_id") Long productId
+    ) {
+        crawlingProductService.deleteProduct(productId);
+
+        return ResponseEntity.ok(
+                BasicResponseDto.success("상품이 성공적으로 삭제되었습니다.", null)
         );
     }
 

--- a/src/main/java/com/example/giftrecommender/vector/ProductVectorDeleteListener.java
+++ b/src/main/java/com/example/giftrecommender/vector/ProductVectorDeleteListener.java
@@ -1,0 +1,31 @@
+package com.example.giftrecommender.vector;
+
+import com.example.giftrecommender.vector.event.ProductDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "vector", name = "enabled", havingValue = "true")
+public class ProductVectorDeleteListener {
+
+    private final ProductVectorService productVectorService;
+
+    /**
+     * DB 트랜잭션이 "성공적으로 커밋된 후"에만 실행된다.
+     * - DB 삭제 실패/롤백이면 호출되지 않음
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProductDeleted(ProductDeletedEvent event) {
+        try {
+            productVectorService.deleteProduct(event.productId());
+        } catch (Exception e) {
+            log.error("[VECTOR][AFTER_COMMIT] delete failed - productId={}", event.productId(), e);
+        }
+    }
+}

--- a/src/main/java/com/example/giftrecommender/vector/ProductVectorService.java
+++ b/src/main/java/com/example/giftrecommender/vector/ProductVectorService.java
@@ -129,6 +129,36 @@ public class ProductVectorService {
         qdrant.upsertAsync(upsert).get(10, TimeUnit.SECONDS);
     }
 
+    /*
+     * Qdrant에서 상품 벡터(포인트) 삭제
+     */
+    public void deleteProduct(Long productId) throws Exception {
+        if (productId == null) {
+            log.warn("[VECTOR] delete skip - productId is null");
+            return;
+        }
+
+        Points.PointId pid = Points.PointId.newBuilder()
+                .setNum(productId)
+                .build();
+
+        Points.PointsIdsList idsList = Points.PointsIdsList.newBuilder()
+                .addIds(pid)
+                .build();
+
+        Points.PointsSelector selector = Points.PointsSelector.newBuilder()
+                .setPoints(idsList)
+                .build();
+
+        Points.DeletePoints delete = Points.DeletePoints.newBuilder()
+                .setCollectionName(qdrantProps.getCollection())
+                .setPoints(selector)
+                .build();
+
+        qdrant.deleteAsync(delete).get(10, TimeUnit.SECONDS);
+        log.info("[VECTOR] delete ok - productId={}", productId);
+    }
+
 
     @Deprecated(forRemoval = true)
     public void upsertProduct(Long productId, String title, long price) throws Exception {

--- a/src/main/java/com/example/giftrecommender/vector/event/ProductDeletedEvent.java
+++ b/src/main/java/com/example/giftrecommender/vector/event/ProductDeletedEvent.java
@@ -1,0 +1,3 @@
+package com.example.giftrecommender.vector.event;
+
+public record ProductDeletedEvent(Long productId) {}


### PR DESCRIPTION
## 변경 내용
- 관리자 상품 삭제 API 추가 (`DELETE /api/admin/products/{product_id}`)
- 상품 삭제 시 DB에서 상품 삭제 후 `ProductDeletedEvent` 발행
- 트랜잭션 커밋 이후(`AFTER_COMMIT`) `ProductVectorDeleteListener`에서 Qdrant 포인트 삭제
- Qdrant 포인트 삭제용 `ProductVectorService.deleteProduct()` 추가
- 벡터 삭제 실패 예외 코드(`VECTOR_DELETE_FAILED`) 추가 및 메시지 정리

## 설계 포인트
- Qdrant는 DB 트랜잭션에 참여하지 않는 외부 시스템이라 트랜잭션 내부에서 바로 호출하지 않고 `AFTER_COMMIT` 후처리로 분리
- DB 삭제가 확정된 후에만 벡터 삭제가 실행되므로 DB–벡터 스토어 정합성을 안정적으로 유지

## 테스트
- 삭제 요청 시 Hibernate delete 쿼리 수행 후, 커밋 이후 Qdrant delete 로그(`[VECTOR] delete ok`) 확인
- 응답: `200 OK`, `data: null`